### PR TITLE
When the window_size was lower than the `ACK_RATIO`

### DIFF
--- a/lib/lumberjack/beats/server.rb
+++ b/lib/lumberjack/beats/server.rb
@@ -419,7 +419,7 @@ module Lumberjack module Beats
     def ack?(sequence)
       if @window_size == sequence
         true
-      elsif sequence % @every == 0
+      elsif @every != 0 && sequence % @every == 0
         true
       else
         false

--- a/logstash-input-beats.gemspec
+++ b/logstash-input-beats.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = "logstash-input-beats"
-  s.version         = "0.9.1"
+  s.version         = "0.9.2"
   s.licenses        = ["Apache License (2.0)"]
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/lumberjack/beats/acking_protocol_v2_spec.rb
+++ b/spec/lumberjack/beats/acking_protocol_v2_spec.rb
@@ -28,4 +28,13 @@ describe Lumberjack::Beats::AckingProtocolV2 do
       expect(results.count(true)).to eq(1)
     end
   end
+
+  context "when the windows size is lower than the ack_ratio" do
+    let(:number_of_events) { 2 }
+
+    it "should return true only once" do
+      expect(results.size).to eq(number_of_events)
+      expect(results.count(true)).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
we were doing the modulo with a 0. I have changed the logic when the
window size is lower than the `ACK_RATIO` we will only ack at the end of
the sequence.