### PR TITLE
Fix/catch epipe error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,13 +7,6 @@ bin
 *.bz2
 *.gz
 src/github.com/alecthomas/gozmq
-vendor/jemalloc/*/
-vendor/libuuid/*/
-vendor/lz4/lz4-r74/
-vendor/openssl/*/
-vendor/zeromq/*/
-vendor/libsodium/*/
-vendor/zlib/*/
 nacl.public
 nacl.secret
 .logstash-forwarder
@@ -26,3 +19,5 @@ logstash-forwarder
 *.crt
 *.key
 *.json
+vendor/
+.bundle/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.9.3
+  - Connection#run should rescue `Broken Pipe Error` #5
+
 # 0.9.2
   - fix an issue with the incorrectly calculated ack when the window_size was smaller than the ACK_RATIO see  https://github.com/logstash-plugins/logstash-input-beats/issues/3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.9.3
   - Connection#run should rescue `Broken Pipe Error` #5
+  - Fix a `SystemCallErr` issue on windows when shutting down the server #9
 
 # 0.9.2
   - fix an issue with the incorrectly calculated ack when the window_size was smaller than the ACK_RATIO see  https://github.com/logstash-plugins/logstash-input-beats/issues/3

--- a/lib/lumberjack/beats/server.rb
+++ b/lib/lumberjack/beats/server.rb
@@ -314,7 +314,7 @@ module Lumberjack module Beats
       while !server.closed?
         read_socket(&block)
       end
-    rescue EOFError, OpenSSL::SSL::SSLError, IOError, Errno::ECONNRESET
+    rescue EOFError, OpenSSL::SSL::SSLError, IOError, Errno::ECONNRESET, Errno::EPIPE
       # EOF or other read errors, only action is to shutdown which we'll do in
       # 'ensure'
     ensure

--- a/lib/lumberjack/beats/server.rb
+++ b/lib/lumberjack/beats/server.rb
@@ -314,9 +314,17 @@ module Lumberjack module Beats
       while !server.closed?
         read_socket(&block)
       end
-    rescue EOFError, OpenSSL::SSL::SSLError, IOError, Errno::ECONNRESET, Errno::EPIPE
+    rescue EOFError,
+      OpenSSL::SSL::SSLError,
+      IOError,
+      Errno::ECONNRESET,
+      Errno::EPIPE
       # EOF or other read errors, only action is to shutdown which we'll do in
       # 'ensure'
+    rescue
+      # when the server is shutting down we can safely ignore any exceptions
+      # On windows, we can get a `SystemCallErr`
+      raise unless server.closed?
     ensure
       close rescue 'Already closed stream'
     end # def run

--- a/logstash-input-beats.gemspec
+++ b/logstash-input-beats.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = "logstash-input-beats"
-  s.version         = "0.9.2"
+  s.version         = "0.9.3"
   s.licenses        = ["Apache License (2.0)"]
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/lumberjack/beats/connection_spec.rb
+++ b/spec/lumberjack/beats/connection_spec.rb
@@ -13,11 +13,12 @@ describe "Connnection" do
 
   context "when the server is running" do
     before do
-      expect(socket).to receive(:sysread).at_least(:once).with(Lumberjack::Beats::Connection::READ_SIZE).and_return("")
+      allow(socket).to receive(:sysread).with(Lumberjack::Beats::Connection::READ_SIZE).and_return("")
       allow(socket).to receive(:syswrite).with(anything).and_return(true)
       allow(socket).to receive(:close)
+    end
 
-
+    it "should ack the end of a sequence" do
       expectation = receive(:feed)
         .with("")
         .and_yield(:version, Lumberjack::Beats::Parser::PROTOCOL_VERSION_1)
@@ -26,11 +27,14 @@ describe "Connnection" do
       random_number_of_events.times { |n| expectation.and_yield(:data, start_sequence + n + 1, payload) }
 
       expect_any_instance_of(Lumberjack::Beats::Parser).to expectation
-    end
-
-    it "should ack the end of a sequence" do
       expect(socket).to receive(:syswrite).with(["1A", random_number_of_events + start_sequence].pack("A*N"))
       connection.read_socket
+    end
+
+    it "should not ignore any exception raised by `#sysread`" do
+      expect(server).to receive(:closed?).and_return(false)
+      expect(connection).to receive(:read_socket).and_raise("Something went wrong")
+      expect { |b| connection.run(&b) }.to raise_error
     end
   end
 

--- a/spec/lumberjack/beats/connection_spec.rb
+++ b/spec/lumberjack/beats/connection_spec.rb
@@ -36,12 +36,20 @@ describe "Connnection" do
 
   context "when the server stop" do
     let(:server) { double("server", :closed? => true) }
+
     before do
       expect(socket).to receive(:close).and_return(true)
     end
 
     it "stop reading from the socket" do
       expect { |b| connection.run(&b) }.not_to yield_control
+    end
+
+    it "should ignore any exception raised by `#sysread`" do
+      expect(server).to receive(:closed?).and_return(false)
+      expect(server).to receive(:closed?).and_return(true)
+      expect(connection).to receive(:read_socket).and_raise("Something went wrong")
+      expect { |b| connection.run(&b) }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
When reading from the socket we should gracefully rescue Broken Pipe err
and close the socket

Fixes #5 and #9 