### PR TITLE
parse and set @timestamp if in original message

### DIFF
--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -156,7 +156,6 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
   rescue LogStash::TimestampParserError => e
     LOGGER.warn("Error parsing @timestamp string, setting current time to @timestamp",
       :value => ts.inspect, :exception => e.message)
-    end
   end
 
   private


### PR DESCRIPTION
we plan to always send '@timestamp'. So filters have to update '@timestamp' if required. Timestamps set by codec will be ignored by this change