### PR TITLE
Make sure the `add_field` and the `tags` options from the config are popagated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.9.4
+  - Correctly decorate the event with the `add_field` and `tags` option from the config #12
 # 0.9.3
   - Connection#run should rescue `Broken Pipe Error` #5
   - Fix a `SystemCallErr` issue on windows when shutting down the server #9

--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -137,10 +137,10 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
     else
       # All codecs expects to work on string
       @codec.decode(target_field.to_s) do |decoded|
-        decorate(decoded)
         ts = coerce_ts(map.delete("@timestamp"))
         decoded["@timestamp"] = ts unless ts.nil?
         map.each { |k, v| decoded[k] = v }
+        decorate(decoded)
         return decoded
       end
     end

--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -125,13 +125,15 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
     @lumberjack.close
   end
 
-  private
+  public
   def create_event(codec, map)
     # Filebeats uses the `message` key and LSF `line`
     target_field = target_field_for_codec ? map.delete(target_field_for_codec) : nil
 
     if target_field.nil?
-      return LogStash::Event.new(map) 
+      event = LogStash::Event.new(map) 
+      decorate(event)
+      return event
     else
       # All codecs expects to work on string
       @codec.decode(target_field.to_s) do |decoded|

--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -131,10 +131,9 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
     target_field = target_field_for_codec ? map.delete(target_field_for_codec) : nil
 
     if target_field.nil?
-      return LogStash::Event.new(map)
+      return LogStash::Event.new(map) 
     else
-
-      # All codes expects to work on string
+      # All codecs expects to work on string
       @codec.decode(target_field.to_s) do |decoded|
         decorate(decoded)
         ts = coerce_ts(map.delete("@timestamp"))
@@ -151,10 +150,10 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
     timestamp = LogStash::Timestamp.coerce(ts)
     return timestamp if timestamp
 
-    LOGGER.warn("Unrecognized @timestamp value, setting current time to @timestamp",
+    @logger.warn("Unrecognized @timestamp value, setting current time to @timestamp",
       :value => ts.inspect)
   rescue LogStash::TimestampParserError => e
-    LOGGER.warn("Error parsing @timestamp string, setting current time to @timestamp",
+    @logger.warn("Error parsing @timestamp string, setting current time to @timestamp",
       :value => ts.inspect, :exception => e.message)
   end
 

--- a/logstash-input-beats.gemspec
+++ b/logstash-input-beats.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = "logstash-input-beats"
-  s.version         = "0.9.3"
+  s.version         = "0.9.4"
   s.licenses        = ["Apache License (2.0)"]
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/beats_spec.rb
+++ b/spec/inputs/beats_spec.rb
@@ -97,7 +97,7 @@ describe LogStash::Inputs::Beats do
     end
 
     context "#create_event" do
-      let(:config) { super.merge({ "add_field" => { "foo" => "bar" }, "tags" => ["bonjour"]}) }
+      let(:config) { super.merge({ "add_field" => { "foo" => "bar", "[@metadata][hidden]" => "secret"}, "tags" => ["bonjour"]}) }
       let(:event_map) { { "hello" => "world" } }
       let(:codec) { LogStash::Codecs::Plain.new }
 
@@ -105,6 +105,7 @@ describe LogStash::Inputs::Beats do
         it "decorates the event" do
           event = beats.create_event(codec, event_map)
           expect(event["foo"]).to eq("bar")
+          expect(event["[@metadata][hidden]"]).to eq("secret")
           expect(event["tags"]).to include("bonjour")
         end
       end
@@ -115,6 +116,7 @@ describe LogStash::Inputs::Beats do
         it "decorates the event" do
           event = beats.create_event(beats.codec, event_map)
           expect(event["foo"]).to eq("bar")
+          expect(event["[@metadata][hidden]"]).to eq("secret")
           expect(event["tags"]).to include("bonjour")
         end
       end


### PR DESCRIPTION
When an event was sent to logstash from topbeats logstash wasn't decorating the event to add the `add_field` and the `tags` from the configuration.

Fix #12 