### PR TITLE
Correctly merge multiline events with the codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2.0.1
+  - Correctly merge multiple line with the multiline codec ref: #24
 # 2.0.0
   - Add support for stream identity, the ID will be generated from beat.id+resource_id or beat.name + beat.source if not present #22 #13
     The identity allow the multiline codec to correctly merge string from multiples files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # 2.0.1
+  - Copy the `beat.hostname` field into the `host` field for better compatibility with the other Logstash plugins #28
   - Correctly merge multiple line with the multiline codec ref: #24
 # 2.0.0
   - Add support for stream identity, the ID will be generated from beat.id+resource_id or beat.name + beat.source if not present #22 #13
     The identity allow the multiline codec to correctly merge string from multiples files.
-  - Copy the `beat.hostname` field into the `host` field for better compatibility with the other Logstash plugins #28
 # 0.9.6
   - Fix an issue with rogue events created by buffered codecs #19
 # 0.9.5

--- a/logstash-input-beats.gemspec
+++ b/logstash-input-beats.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = "logstash-input-beats"
-  s.version         = "2.0.0"
+  s.version         = "2.0.1"
   s.licenses        = ["Apache License (2.0)"]
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The problem was the buffer wasn't cleared correctly when received a new
event header resulting in duplicates of lines. Added a test to cover it

Fixes #22