### PR TITLE
Copies the beat.hostname field into host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.0.0
   - Add support for stream identity, the ID will be generated from beat.id+resource_id or beat.name + beat.source if not present #22 #13
     The identity allow the multiline codec to correctly merge string from multiples files.
+  - Copy the `beat.hostname` field into the `host` field for better compatibility with the other Logstash plugins #28
 # 0.9.6
   - Fix an issue with rogue events created by buffered codecs #19
 # 0.9.5

--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -128,6 +128,12 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
 
   public
   def create_event(map, identity_stream)
+    # Copy beat.hostname into host
+    host = map.fetch("beat", {})["hostname"]
+    if host
+      map["host"] = host
+    end
+
     # Filebeats uses the `message` key and LSF `line`
     target_field = target_field_for_codec ? map.delete(target_field_for_codec) : nil
 

--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -156,7 +156,7 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
   private
   def copy_beat_hostname(event)
     host = event["beat"] ? event["beat"]["hostname"] : nil
-    if host and not event["host"]
+    if host && event["host"].nil?
       event["host"] = host
     end
   end

--- a/logstash-input-beats.gemspec
+++ b/logstash-input-beats.gemspec
@@ -31,5 +31,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry"
   s.add_development_dependency "rspec-wait"
   s.add_development_dependency "logstash-devutils", "~> 0.0.18"
+  s.add_development_dependency "logstash-codec-json"
 end
 

--- a/spec/inputs/beats_spec.rb
+++ b/spec/inputs/beats_spec.rb
@@ -128,6 +128,15 @@ describe LogStash::Inputs::Beats do
         end
       end
 
+      context "with a beat.hostname field but without the message" do
+        let(:event_map) { {"beat" => {"hostname" => "linux01"} } }
+
+        it "copies it to the host field" do
+          event = beats.create_event(event_map, identity_stream)
+          expect(event["host"]).to eq("linux01")
+        end
+      end
+
       context "without a beat.hostname field" do
         let(:event_map) { {"message" => "hello", "beat" => {"name" => "linux01"} } }
 

--- a/spec/inputs/beats_spec.rb
+++ b/spec/inputs/beats_spec.rb
@@ -117,6 +117,25 @@ describe LogStash::Inputs::Beats do
           expect(event).to be_nil
         end
       end
+
+      context "with a beat.hostname field" do
+        let(:event_map) { {"message" => "hello", "beat" => {"hostname" => "linux01"} } }
+
+        it "copies it to the host field" do
+          event = beats.create_event(event_map, identity_stream)
+          expect(event["host"]).to eq("linux01")
+        end
+      end
+
+      context "without a beat.hostname field" do
+        let(:event_map) { {"message" => "hello", "beat" => {"name" => "linux01"} } }
+
+        it "should not add a host field" do
+          event = beats.create_event(event_map, identity_stream)
+          expect(event["beat"]["name"]).to eq("linux01")
+          expect(event["host"]).to be_nil
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Does this before the codec is applied, so if a "host" field is the result of parsing, that one will override it. Closes #25.

@ph Can you have a look at this one, please? I don't really know what I'm doing in ruby :-).