### PR TITLE
Release a new version of the gem without any included dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2.1.1
+  - Release a new version of the gem that doesn't included any other gems, 2.1.0 is yanked from rubygems 
 # 2.1.0
   - Refactor of the code to make it easier to unit test
   - Fix a conncurrency error on high load on the SizeQueue #37

--- a/logstash-input-beats.gemspec
+++ b/logstash-input-beats.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = "logstash-input-beats"
-  s.version         = "2.1.0"
+  s.version         = "2.1.1"
   s.licenses        = ["Apache License (2.0)"]
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # Files
-  s.files = Dir["lib/**/*","spec/**/*","vendor/**/*","*.gemspec","*.md","CONTRIBUTORS","Gemfile","LICENSE","NOTICE.TXT"]
+  s.files = Dir["lib/**/*","spec/**/*","*.gemspec","*.md","CONTRIBUTORS","Gemfile","LICENSE","NOTICE.TXT"]
 
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
2.1.0 included the dependencies in the released gem package, this PR
fix the problem and also remove `vendor/` from the gemspec's files
attributes. The 2.1.0 will be yanked from rubygems.