### PR TITLE
Fix a small issue with the way the tests are setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.1.2
+  - Catch the `java.lang.InterruptedException` in the events broker
+  - Give a bit more time to the Thread to be started in the test #42
 # 2.1.1
   - Release a new version of the gem that doesn't included any other gems, 2.1.0 is yanked from rubygems 
 # 2.1.0

--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -217,9 +217,9 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
         while !stop?
           @output_queue << @buffered_queue.take
         end
-      rescue InterruptionException => e
+      rescue java.lang.InterruptedException => e
         # If we are shutting down without waiting the queue to unblock
-        # we will get an `InterruptionException` in that context we will not log it.
+        # we will get an `java.lang.InterruptionException` in that context we will not log it.
         @logger.error("Beats input: bufferered queue exception", :exception => e) unless stop?
       rescue => e
         @logger.error("Beats input: unexpected exception", :exception => e)

--- a/logstash-input-beats.gemspec
+++ b/logstash-input-beats.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = "logstash-input-beats"
-  s.version         = "2.1.1"
+  s.version         = "2.1.2"
   s.licenses        = ["Apache License (2.0)"]
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Depending of the load on the CI, this test could work or Not
this PR give a bit more time to start and use Try {} to try multiple
time before failing.

Also rescue `java.lang.InterruptedException` since its a java exception we need to prefix it with the java context.

It should fix the two failing test, which don't happen all the time :(
```
 1) LogStash::Inputs::Beats#handle_new_connection when an exception occur calls flush on the handler and tag the events
     Failure/Error: plugin.handle_new_connection(connection)
     NoMethodError:
       undefined method `<<' for nil:NilClass
     # ./lib/logstash/inputs/beats.rb:198:in `handle_new_connection'
     # ./lib/logstash/inputs/beats.rb:193:in `handle_new_connection'
     # ./spec/inputs/beats_spec.rb:112:in `(root)'

  2) LogStash::Inputs::BeatsSupport::ConnectionHandler#process with a codec queue is blocked raise an exception
     Failure/Error: Unable to find matching line from backtrace
     NameError:
       uninitialized constant LogStash::Inputs::Beats::InterruptionException
     # ./lib/logstash/inputs/beats.rb:218:in `start_buffer_broker'

```