### PR TITLE
Parse compressed body directly

### DIFF
--- a/lib/lumberjack/beats/server.rb
+++ b/lib/lumberjack/beats/server.rb
@@ -308,7 +308,27 @@ module Lumberjack module Beats
       transition(:header, 2)
 
       # Parse the uncompressed payload.
-      feed(original, &block)
+      # feed(original, &block)
+      off = 0
+      while off < (original.size - 10) # account for data frame header
+        version, code = original[off, 2].bytes.to_a
+        if !(version == PROTOCOL_VERSION_2 and code == FRAME_JSON_DATA)
+          # fallback to original feed method for backwards compatibility to
+          # logstash-forwarder
+          feed(original[off..-1], &block)
+          return
+        end
+
+        off += 2
+        @sequence, payload_size = original[off, 8].unpack('NN')
+        off += 8
+        if (off + payload_size) > original.size
+          raise "JSON payload length exceeds uncompressed message"
+        end
+        payload = original[off, payload_size]
+        off += payload_size
+        yield :json, @sequence, Lumberjack::Beats::json.load(payload)
+      end
     end
   end # class Parser
 


### PR DESCRIPTION
Fixes connection failures due to buffer handling if data read from socket
contain partial content from next message by parsing decompressed content directly.

Fix is specific for libbeat output plugin and fixes issues encountered in PR elastic/beats#941.
Errors encountered have been similar to: #44, #35, #34

Checking throughput on hetzner test-machine improved by ~10% from 20k eps to 22k eps. Enabling PR elastic/beats#941, throughput increased to ~25.5k eps. With 2 workers it increased to 43k eps. 