### PR TITLE
Make sure we stop the thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2.1.3
+  - Make sure we stop all the threads after running the tests #48
 # 2.1.2
   - Catch the `java.lang.InterruptedException` in the events broker
   - Give a bit more time to the Thread to be started in the test #42

--- a/logstash-input-beats.gemspec
+++ b/logstash-input-beats.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = "logstash-input-beats"
-  s.version         = "2.1.2"
+  s.version         = "2.1.3"
   s.licenses        = ["Apache License (2.0)"]
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The server was still reading the socket when the test was completed
making other tests fails.

Since we are mocking the connection to test the behavior of thread
connection handler calling `#stop` on the plugin wont correctly shutdown
the plugin. Until we have implemented a non blocking stack for beats
inputs I suggest we force to stop the server at the end of running the
tests.

Note in this change doesnt change the test for making sure the plugin
can be stopped.

Fixes #48