### PR TITLE
Change the log level on disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2.1.4
+  - Change the `logger#warn` for `logger.debug` when a peer get disconnected, keep alive check from proxy can generate a lot of logs  #46
 # 2.1.3
   - Make sure we stop all the threads after running the tests #48
 # 2.1.2

--- a/logstash-input-beats.gemspec
+++ b/logstash-input-beats.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = "logstash-input-beats"
-  s.version         = "2.1.3"
+  s.version         = "2.1.4"
   s.licenses        = ["Apache License (2.0)"]
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Instead of using `logger.warn` we use `logger.debug` when a client
disconnect, when debugging an evironment is nice to see why the host was
actually disconnected. But when running the input beats behind a proxy
the keep alive check can make the log a bit noisy.

Fixes #46