### PR TITLE
TLS Client verification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: false
+language: ruby
+cache: bundler
+rvm:
+  - jruby-1.7.24
+before_script:
+  - bundle exec rake test:integration:setup
+script: 
+  - bundle exec rspec spec
+  - bundle exec rspec spec --tag integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.1.5
+# 2.2.0
   - The server can now do client side verification by providing a list of certificate authorities and configuring the `ssl_verify_mode`,
     the server can use `peer`, if the client send a certificate it will be validated. Using `force_peer` will make sure the client provide a certificate
     and it will be validated with the know CA.  #8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.5
+  - The server can now do client side verification by providing a list of certificate authorities and configuring the `ssl_verify_mode`,
+    the server can use `peer`, if the client send a certificate it will be validated. Using `force_peer` will make sure the client provide a certificate
+    and it will be validated with the know CA.  #8
 # 2.1.4
   - Change the `logger#warn` for `logger.debug` when a peer get disconnected, keep alive check from proxy can generate a lot of logs  #46
 # 2.1.3

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,17 @@
+# encoding: utf-8
+
+OS_PLATFORM = RbConfig::CONFIG["host_os"]
+VENDOR_PATH = File.expand_path(File.join(File.dirname(__FILE__), "vendor"))
+
+if OS_PLATFORM == "linux"
+  FILEBEAT_URL = "https://beats-nightlies.s3.amazonaws.com/filebeat/filebeat-5.0.0-nightlylatest-#{RbConfig::CONFIG["host_cpu"]}.tar.gz"
+elsif OS_PLATFORM == "darwin"
+  FILEBEAT_URL = "https://beats-nightlies.s3.amazonaws.com/filebeat/filebeat-5.0.0-nightlylatest-darwin.tgz"
+end
+
+LSF_URL = "https://download.elastic.co/logstash-forwarder/binaries/logstash-forwarder_#{OS_PLATFORM}_amd64"
+
+require "fileutils"
 @files=[]
 
 task :default do
@@ -5,3 +19,48 @@ task :default do
 end
 
 require "logstash/devutils/rake"
+
+namespace :test do
+  namespace :integration do
+    task :setup do
+      Rake::Task["test:integration:setup:filebeat"].invoke
+      Rake::Task["test:integration:setup:lsf"].invoke
+    end
+
+    namespace :setup do
+      desc "Download lastest stable version of Logstash-forwarder"
+      task :lsf do
+        destination = File.join(VENDOR_PATH, "logstash-forwarder")
+        FileUtils.rm_rf(destination)
+        FileUtils.mkdir_p(destination)
+        download_destination = File.join(destination, "logstash-forwarder")
+        puts "Logstash-forwarder: downloading from #{LSF_URL} to #{download_destination}"
+        download(LSF_URL, download_destination)
+        File.chmod(0755, download_destination)
+      end
+
+      desc "Download nigthly filebeat for integration testing"
+      task :filebeat do
+        FileUtils.mkdir_p(VENDOR_PATH)
+        download_destination = File.join(VENDOR_PATH, "filebeat.tar.gz")
+        destination = File.join(VENDOR_PATH, "filebeat")
+        FileUtils.rm_rf(download_destination)
+        FileUtils.rm_rf(destination)
+        FileUtils.rm_rf(File.join(VENDOR_PATH, "filebeat.tar"))
+        puts "Filebeat: downloading from #{FILEBEAT_URL} to #{download_destination}"
+        download(FILEBEAT_URL, download_destination)
+
+        untar_all(download_destination, File.join(VENDOR_PATH, "filebeat")) { |e| e }
+      end
+    end
+  end
+end
+
+# Uncompress all the file from the archive this only work with 
+# one level directory structure and its fine for LSF and filebeat packaging.
+def untar_all(file, destination)
+  untar(file) do |entry| 
+    out = entry.full_name.split("/").last
+    File.join(destination, out)
+  end
+end

--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -68,6 +68,27 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
   # SSL key passphrase to use.
   config :ssl_key_passphrase, :validate => :password
 
+  # Validate client certificates against theses authorities
+  # You can defined multiples files or path, all the certificates will
+  # be read and added to the trust store. You need to configure the `ssl_verify_mode`
+  # to `peer` or `force_peer` to enable the verification.
+  #
+  # This feature only support certificate directly signed by your root ca.
+  # Intermediate CA are currently not supported.
+  # 
+  config :ssl_certificate_authorities, :validate => :array, :default => []
+
+  # By default the server dont do any client verification,
+  # 
+  # `peer` will make the server ask the client to provide a certificate,
+  # if the client provide the certificate it will be validated.
+  #
+  # `force_peer` will make the server ask the client for their certificate, if the clients
+  # doesn't provide it the connection will be closed.
+  #
+  # This option need to be used with `ssl_certificate_authorities` and a defined list of CA.
+  config :ssl_verify_mode, :validate => ["none", "peer", "force_peer"], :default => "none"
+
   # The number of seconds before we raise a timeout,
   # this option is useful to control how much time to wait if something is blocking the pipeline.
   config :congestion_threshold, :validate => :number, :default => 5
@@ -87,9 +108,16 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
     end
 
     @logger.info("Beats inputs: Starting input listener", :address => "#{@host}:#{@port}")
-    @lumberjack = Lumberjack::Beats::Server.new(:address => @host, :port => @port,
-      :ssl => @ssl, :ssl_certificate => @ssl_certificate, :ssl_key => @ssl_key,
-      :ssl_key_passphrase => @ssl_key_passphrase)
+
+
+    @lumberjack = Lumberjack::Beats::Server.new(:address => @host,
+      :port => @port,
+      :ssl => @ssl,
+      :ssl_certificate => @ssl_certificate,
+      :ssl_key => @ssl_key,
+      :ssl_key_passphrase => @ssl_key_passphrase,
+      :ssl_certificate_authorities => @ssl_certificate_authorities,
+      :ssl_verify_mode => @ssl_verify_mode)
 
     # in 1.5 the main SizeQueue doesnt have the concept of timeout
     # We are using a small plugin buffer to move events to the internal queue
@@ -103,8 +131,8 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
     @codec = LogStash::Codecs::IdentityMapCodec.new(@codec)
 
     # Keep a list of active connections so we can flush their codec on shutdown
-    
-    # Use threadsafe gem, since we have a strict dependency on concurrent-ruby 0.9.2 
+
+    # Use threadsafe gem, since we have a strict dependency on concurrent-ruby 0.9.2
     # in the core
     @connections_list = ThreadSafe::Hash.new
   end # def register
@@ -127,13 +155,13 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
         connection = @lumberjack.accept # call that creates a new connection
         # if the connection is nil the connection was closed upstream,
         # so we will try in another iteration to recover or stop.
-        next if connection.nil? 
+        next if connection.nil?
 
-        Thread.new do 
+        Thread.new do
           handle_new_connection(connection)
         end
       else
-        @logger.warn("Beats input: the pipeline is blocked, temporary refusing new connection.", 
+        @logger.warn("Beats input: the pipeline is blocked, temporary refusing new connection.",
                      :reconnect_backoff_sleep => RECONNECT_BACKOFF_SLEEP)
         sleep(RECONNECT_BACKOFF_SLEEP)
       end
@@ -186,9 +214,9 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
     @logger.warn("Beats input: The circuit breaker has detected a slowdown or stall in the pipeline, the input is closing the current connection and rejecting new connection until the pipeline recover.",
                 :exception => e.class)
   rescue Exception => e # If we have a malformed packet we should handle that so the input doesn't crash completely.
-    @logger.error("Beats input: unhandled exception", 
+    @logger.error("Beats input: unhandled exception",
                   :exception => e,
-                  :backtrace => e.backtrace) 
+                  :backtrace => e.backtrace)
   ensure
     transformer = LogStash::Inputs::BeatsSupport::EventTransformCommon.new(self)
 

--- a/logstash-input-beats.gemspec
+++ b/logstash-input-beats.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = "logstash-input-beats"
-  s.version         = "2.1.4"
+  s.version         = "2.1.5"
   s.licenses        = ["Apache License (2.0)"]
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -33,5 +33,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-wait"
   s.add_development_dependency "logstash-devutils", "~> 0.0.18"
   s.add_development_dependency "logstash-codec-json"
+  s.add_development_dependency "childprocess" # To make filebeat/LSF integration test easier to write.
 end
 

--- a/logstash-input-beats.gemspec
+++ b/logstash-input-beats.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = "logstash-input-beats"
-  s.version         = "2.1.5"
+  s.version         = "2.2.0"
   s.licenses        = ["Apache License (2.0)"]
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration/filebeat_spec.rb
+++ b/spec/integration/filebeat_spec.rb
@@ -1,0 +1,235 @@
+# encoding: utf-8
+require "logstash/inputs/beats"
+require "stud/temporary"
+require "flores/pki"
+require "fileutils"
+require "thread"
+require "spec_helper"
+require "yaml"
+require "fileutils"
+require "flores/pki"
+require_relative "../support/flores_extensions"
+require_relative "../support/file_helpers"
+require_relative "../support/integration_shared_context"
+require_relative "../support/client_process_helpers"
+
+FILEBEAT_BINARY = File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "vendor", "filebeat", "filebeat"))
+
+describe "Filebeat", :integration => true do
+  include ClientProcessHelpers
+  include FileHelpers
+
+  before :all do
+    unless File.exist?(FILEBEAT_BINARY)
+      raise "Cannot find `Filebeat` binary in `vendor/filebeat`. Did you run `bundle exec rake test:integration:setup` before running the integration suite?"
+    end
+  end
+
+  include_context "beats configuration"
+
+  # Filebeat related variables
+  let(:cmd) { [filebeat_exec, "-c", filebeat_config_path, "-e", "-v"] }
+
+  let(:filebeat_exec) { FILEBEAT_BINARY }
+
+  let_empty_tmp_file(:registry_file)
+  let(:filebeat_config) do
+    { 
+      "filebeat" => { 
+        "prospectors" => [{ "paths" => [log_file],  "input_type" => "log" }],
+        "registry_file" => registry_file,
+        "scan_frequency" => "1s"
+      },
+      "output" => { 
+        "logstash" => { "hosts" => ["#{host}:#{port}"] },
+        "logging" => { "level" => "debug" }
+      }
+    }
+  end
+
+  let_tmp_file(:filebeat_config_path) { YAML.dump(filebeat_config) }
+  before :each do
+    start_client
+    sleep(2) # give some time to FB to send somthing
+    stop_client
+  end
+
+  ###########################################################
+  shared_context "Root CA" do
+    let(:root_ca) { Flores::PKI.generate("CN=root.localhost") }
+    let(:root_ca_certificate) { root_ca.first }
+    let(:root_ca_key) { root_ca.last }
+    let_tmp_file(:root_ca_certificate_file) { root_ca_certificate }
+  end
+
+  shared_context "Intermediate CA" do
+    let(:intermediate_ca) { Flores::PKI.create_intermediate_certificate("CN=intermediate.localhost", root_ca_certificate, root_ca_key) }
+    let(:intermediate_ca_certificate) { intermediate_ca.first }
+    let(:intermediate_ca_key) { intermediate_ca.last }
+    let_tmp_file(:certificate_authorities_chain) { Flores::PKI.chain_certificates(root_ca_certificate, intermediate_ca_certificate) }
+  end
+
+  ############################################################
+  # Actuals tests 
+  context "Plain TCP" do
+    include_examples "send events"
+  end
+
+  context "TLS" do
+    context "Server verification" do
+      let(:filebeat_config) do
+        super.merge({
+          "output" => {
+            "logstash" => {
+              "hosts" => ["#{host}:#{port}"],
+              "tls" => { "certificate_authorities" => certificate_authorities }
+            },
+            "logging" => { "level" => "debug" }
+          }})
+      end
+
+      let(:input_config) do
+        super.merge({ 
+          "ssl" => true,
+          "ssl_certificate" => certificate_file,
+          "ssl_key" => certificate_key_file
+        })
+      end
+
+      let(:certificate_authorities) { [certificate_file] }
+      let(:certificate_data) { Flores::PKI.generate }
+      let_tmp_file(:certificate_key_file) { certificate_data.last } 
+      let_tmp_file(:certificate_file) { certificate_data.first }
+
+      context "self signed certificate" do
+        include_examples "send events"
+      end
+
+      context "CA root" do
+        include_context "Root CA"
+
+        context "directly signed client certificate" do
+          let(:certificate_authorities) { [root_ca_certificate_file] }
+          let(:certificate_data) { Flores::PKI.create_client_certicate("CN=localhost", root_ca_certificate, root_ca_key) }
+
+          include_examples "send events"
+        end
+
+        context "intermediate CA signs client certificate" do
+          include_context "Intermediate CA"
+
+          let(:certificate_data) { Flores::PKI.create_client_certicate("CN=localhost", intermediate_ca_certificate, intermediate_ca_key) }
+          let(:certificate_authorities) { [certificate_authorities_chain] }
+          
+          include_examples "send events"
+        end
+      end
+
+      context "Client verification / Mutual validation" do
+        let(:filebeat_config) do
+          super.merge({
+            "output" => {
+              "logstash" => {
+                "hosts" => ["#{host}:#{port}"],
+                "tls" => { 
+                  "certificate_authorities" => certificate_authorities,
+                  "certificate" => certificate_file,
+                  "certificate_key" => certificate_key_file
+                }
+              },
+              "logging" => { "level" => "debug" }
+            }})
+        end
+
+        let(:input_config) do
+          super.merge({ 
+            "ssl" => true,
+            "ssl_certificate_authorities" => certificate_authorities,
+            "ssl_certificate" => server_certificate_file,
+            "ssl_key" => server_certificate_key_file,
+            "ssl_verify_mode" => "force_peer"
+          })
+        end
+
+        context "with a self signed certificate" do
+          let(:certificate_authorities) { [certificate_file] }
+          let(:certificate_data) { Flores::PKI.generate }
+          let_tmp_file(:certificate_key_file) { certificate_data.last } 
+          let_tmp_file(:certificate_file) { certificate_data.first }
+          let_tmp_file(:server_certificate_file) { certificate_data.first }
+          let_tmp_file(:server_certificate_key_file) { certificate_data.last }
+
+          include_examples "send events"
+        end
+
+        context "CA root" do
+          include_context "Root CA"
+
+          let_tmp_file(:server_certificate_file) { server_certificate_data.first }
+          let_tmp_file(:server_certificate_key_file) { server_certificate_data.last }
+
+          context "directly signed client certificate" do
+            let(:certificate_authorities) { [root_ca_certificate_file] }
+            let(:certificate_data) { Flores::PKI.create_client_certicate("CN=localhost", root_ca_certificate, root_ca_key) }
+            let(:server_certificate_data) { Flores::PKI.create_client_certicate("CN=localhost", root_ca_certificate, root_ca_key) }
+
+            include_examples "send events"
+          end
+
+
+          # Doesnt work because of this issues in `jruby-openssl`
+          # https://github.com/jruby/jruby-openssl/issues/84
+          xcontext "intermediate create server and client certificate" do
+            include_context "Intermediate CA"
+
+            let(:certificate_data) { Flores::PKI.create_client_certicate("CN=localhost", intermediate_ca_certificate, intermediate_ca_key) }
+            let(:server_certificate_data) { Flores::PKI.create_client_certicate("CN=localhost", intermediate_ca_certificate, intermediate_ca_key) } 
+            let(:certificate_authorities) { [certificate_authorities_chain] }
+
+            include_examples "send events"
+          end
+
+          context "and Secondary CA multiples clients" do
+            context "with CA in different files" do
+              let(:secondary_ca) { Flores::PKI.generate }
+              let(:secondary_ca_key) { secondary_ca.last }
+              let(:secondary_ca_certificate) { secondary_ca.first }
+              let_tmp_file(:secondary_ca_certificate_file) { secondary_ca.first }
+
+              let(:secondary_client_certificate_data) { Flores::PKI.create_client_certicate("CN=localhost", secondary_ca_certificate, secondary_ca_key) }
+              let_tmp_file(:secondary_client_certificate_file) { secondary_client_certificate_data.first }
+              let_tmp_file(:secondary_client_certificate_key_file) { secondary_client_certificate_data.last }
+              let(:certificate_authorities) { [root_ca_certificate_file, secondary_ca_certificate_file] }
+              let(:certificate_data) { Flores::PKI.create_client_certicate("CN=localhost", root_ca_certificate, root_ca_key) }
+
+              let(:server_certificate_data) { Flores::PKI.create_client_certicate("CN=localhost", root_ca_certificate, root_ca_key) }
+
+              context "client from primary CA" do 
+                include_examples "send events"
+              end
+
+              context "client from secondary CA" do
+                let(:filebeat_config) do
+                  super.merge({
+                    "output" => {
+                      "logstash" => {
+                        "hosts" => ["#{host}:#{port}"],
+                        "tls" => { 
+                          "certificate_authorities" => certificate_authorities,
+                          "certificate" => secondary_client_certificate_file,
+                          "certificate_key" => secondary_client_certificate_key_file
+                        }
+                      },
+                      "logging" => { "level" => "debug" }
+                    }})
+                end
+
+                include_examples "send events"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/logstash_forwarder_spec.rb
+++ b/spec/integration/logstash_forwarder_spec.rb
@@ -1,0 +1,102 @@
+# encoding: utf-8
+require "logstash/inputs/beats"
+require "logstash/json"
+require "fileutils"
+require_relative "../support/flores_extensions"
+require_relative "../support/file_helpers"
+require_relative "../support/integration_shared_context"
+require_relative "../support/client_process_helpers"
+require "spec_helper"
+
+LSF_BINARY = File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "vendor", "logstash-forwarder", "logstash-forwarder"))
+
+xdescribe "Logstash-Forwarder", :integration => true do
+  include ClientProcessHelpers
+
+  before :all do
+    unless File.exist?(LSF_BINARY)
+      raise "Cannot find `logstash-forwarder` binary in `vendor/logstash-forwarder` Did you run `bundle exec rake test:integration:setup` before running the integration suite?"
+    end
+  end
+
+  let(:client_wait_time) { 5 }
+  include FileHelpers
+  include_context "beats configuration"
+
+  # Filebeat related variables
+  let(:cmd) { [lsf_exec, "-config", lsf_config_path] }
+
+  let(:lsf_exec) { LSF_BINARY }
+  let(:registry_file) { File.expand_path(File.join(File.dirname(__FILE__), "..", "..", ".logstash-forwarder")) }
+  let_tmp_file(:lsf_config_path) { lsf_config }
+  let(:log_file) { f = Stud::Temporary.file; f.close; f.path }
+  let(:lsf_config) do
+ <<-CONFIG
+{
+  "network": {
+    "servers": [ "#{host}:#{port}" ],
+    "ssl ca": "#{certificate_authorities}"
+  },
+  "files": [
+    { "paths": [ "#{log_file}" ] }
+  ]
+}
+ CONFIG
+  end
+  #
+
+  before :each do
+    FileUtils.rm_rf(registry_file) # ensure clean state between runs
+    start_client
+    sleep(1)
+    # let LSF start and than write the logs
+    File.open(log_file, "a") do |f|
+      f.write(events.join("\n") + "\n")
+    end
+  end
+
+  after :each do
+    stop_client
+  end
+
+  context "Plain TCP" do
+    include ClientProcessHelpers
+    let(:certificate_authorities) { "" }
+
+    it "should not send any events" do
+      expect(queue.size).to eq(0), @execution_output
+    end
+  end
+
+  context "TLS" do
+    context "Server Verification" do
+      let(:input_config) do
+        super.merge({ 
+          "ssl" => true,
+          "ssl_certificate" => certificate_file,
+          "ssl_key" => certificate_key_file,
+          "target_field_for_codec" => "line"
+        })
+      end
+
+      let(:certificate_data) { Flores::PKI.generate }
+      let_tmp_file(:certificate_file) { certificate_data.first }
+      let_tmp_file(:certificate_key_file) { certificate_data.last } 
+      let(:certificate_authorities) { certificate_file }
+
+      context "self signed certificate" do
+        include_examples "send events" do
+        end
+      end
+
+      context "invalid CA on the client" do
+        let(:invalid_data) { Flores::PKI.generate }
+        let(:certificate_authorities) { invalid_data.first }
+
+        it "should not send any events" do
+          expect(queue.size).to eq(0), @execution_output
+        end
+      end
+    end
+  end
+end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -6,27 +6,47 @@ require "flores/pki"
 require "fileutils"
 require "thread"
 require "spec_helper"
+require_relative "./support/file_helpers"
+require_relative "./support/flores_extensions"
 
 Thread.abort_on_exception = true
 describe "A client" do
+  include FileHelpers
+
   let(:certificate) { Flores::PKI.generate }
-  let(:certificate_file_crt) { "certificate.crt" }
-  let(:certificate_file_key) { "certificate.key" }
+  let(:certificate_file_crt) do
+     p = Stud::Temporary.file
+     p.write(certificate.first.to_s)
+     p.close
+     p.path
+  end
+
+  let(:certificate_file_key) do
+    p = Stud::Temporary.file
+    p.write(certificate.last.to_s)
+    p.close
+    p.path
+  end
   let(:port) { Flores::Random.integer(1024..65335) }
   let(:tcp_port) { port + 1 }
   let(:host) { "127.0.0.1" }
   let(:queue) { [] }
+  let(:config_ssl) do
+    {
+      :port => port,
+      :address => host,
+      :ssl_certificate => certificate_file_crt,
+      :ssl_key => certificate_file_key
+    }
+  end
+
+  let(:config_tcp) do
+    { :port => tcp_port, :address => host, :ssl => false }
+  end
 
   before :each do
-    expect(File).to receive(:read).at_least(1).with(certificate_file_crt) { certificate.first.to_s }
-    expect(File).to receive(:read).at_least(1).with(certificate_file_key) { certificate.last.to_s }
-
-    tcp_server = Lumberjack::Beats::Server.new(:port => tcp_port, :address => host, :ssl => false)
-
-    ssl_server = Lumberjack::Beats::Server.new(:port => port,
-                                        :address => host,
-                                        :ssl_certificate => certificate_file_crt,
-                                        :ssl_key => certificate_file_key)
+    tcp_server = Lumberjack::Beats::Server.new(config_tcp)
+    ssl_server = Lumberjack::Beats::Server.new(config_ssl)
 
     @tcp_server = Thread.new do
       tcp_server.run { |data, identity_stream| queue << [data, identity_stream] }
@@ -42,7 +62,7 @@ describe "A client" do
               # parser for TCP based server trip.
               # Connection is closed by Server connection object
             end
-          end 
+          end
       end
     end
 
@@ -160,61 +180,333 @@ describe "A client" do
     end
   end
 
-  context "using ssl encrypted connection" do
-    context "with a valid certificate" do
-      it "successfully connect to the server" do
-        expect {
-          Lumberjack::Beats::Client.new(:port => port,
-                                 :host => host,
-                                 :addresses => host,
-                                 :ssl_certificate => certificate_file_crt)
-        }.not_to raise_error
+  context "using TLS/SSL encrypted connection" do
+    context "without a ca chain" do
+      context "with a valid certificate" do
+        it "successfully connect to the server" do
+          expect {
+            Lumberjack::Beats::Client.new(:port => port,
+                                   :host => host,
+                                   :addresses => host,
+                                   :ssl_certificate_authorities => certificate_file_crt)
+          }.not_to raise_error
+        end
+
+        it "should fail connecting to plain tcp server" do
+          expect {
+            Lumberjack::Beats::Client.new(:port => tcp_port,
+                                   :host => host,
+                                   :addresses => host,
+                                   :ssl_certificate_authorities => certificate_file_crt)
+          }.to raise_error(OpenSSL::SSL::SSLError)
+        end
       end
 
-      it "should fail connecting to plain tcp server" do
-        expect {
-          Lumberjack::Beats::Client.new(:port => tcp_port,
-                                 :host => host,
-                                 :addresses => host,
-                                 :ssl_certificate => certificate_file_crt)
-        }.to raise_error(OpenSSL::SSL::SSLError)
-      end
-    end
+      context "with an invalid certificate" do
+        let(:invalid_certificate) { Flores::PKI.generate }
+        let(:invalid_certificate_file) { Stud::Temporary.file.path }
 
-    context "with an invalid certificate" do
-      let(:invalid_certificate) { Flores::PKI.generate }
-      let(:invalid_certificate_file) { "invalid.crt" }
+        it "should refuse to connect" do
+          expect {
+            Lumberjack::Beats::Client.new(:port => port,
+                                          :host => host,
+                                          :addresses => host,
+                                          :ssl_certificate_authorities => invalid_certificate_file)
 
-      before do
-        expect(File).to receive(:read).with(invalid_certificate_file) { invalid_certificate.first.to_s }
+          }.to raise_error(OpenSSL::SSL::SSLError, /certificate verify failed/)
+        end
       end
 
-      it "should refuse to connect" do
-        expect {
+      context "When transmitting a payload" do
+        let(:client) do
           Lumberjack::Beats::Client.new(:port => port,
                                         :host => host,
                                         :addresses => host,
-                                        :ssl_certificate => invalid_certificate_file)
+                                        :ssl_certificate_authorities => certificate_file_crt)
+        end
 
-        }.to raise_error(OpenSSL::SSL::SSLError, /certificate verify failed/)
+        context "json" do
+          let(:options) { super.merge({ :json => true }) }
+          include_examples "transmit payloads"
+        end
+
+        context "v1 frame" do
+          include_examples "transmit payloads"
+        end
       end
     end
+  end
 
-    context "When transmitting a payload" do
-      let(:client) do
-        Lumberjack::Beats::Client.new(:port => port,
-                                      :host => host,
-                                      :addresses => host,
-                                      :ssl_certificate => certificate_file_crt)
+  def write_to_tmp_file(content)
+    file = Stud::Temporary.file
+    file.write(content.to_s)
+    file.close
+    file.path
+  end
+
+  context "Mutual validation" do
+    let(:host) { "localhost" }
+    let(:certificate_duration) { Flores::Random.number(1000..2000) }
+    let(:client) { Lumberjack::Beats::Client.new(options) }
+    let(:options) { { :ssl => true, :port => port, :addresses => host } }
+    let(:config_ssl) do
+      {
+        :port => port,
+        :address => host,
+        :ssl => true,
+        :ssl_verify_mode => "force_peer"
+      }
+    end
+
+    context "with a self signed certificate" do
+      let(:certificate) { Flores::PKI.generate }
+      let_tmp_file(:certificate_file) { certificate.first }
+      let_tmp_file(:certificate_key_file) { certificate.last }
+      let(:options) do
+        super.merge({ :ssl_certificate => certificate_file, 
+                      :ssl_certificate_key => certificate_key_file, 
+                      :ssl_certificate_authorities => certificate_file })
       end
 
-      context "json" do
-        let(:options) { super.merge({ :json => true }) }
+      let(:config_ssl) do
+        super.merge({ :ssl_certificate_authorities => certificate_file,
+                      :ssl_certificate => certificate_file,
+                      :ssl_key => certificate_key_file })
+      end
+
+      include_examples "transmit payloads"
+    end
+
+    context "with certificate authorities" do
+      let(:keysize) { 1024 }
+      let(:exponent) { 65537 }
+      let(:root_ca) { Flores::PKI.generate("CN=root.logstash") }
+      let(:root_ca_certificate) { root_ca.first }
+      let(:root_ca_key) { root_ca.last }
+      let_tmp_file(:root_ca_certificate_file) { root_ca_certificate }
+
+      context "directly signing a certificate" do
+        let(:client_certificate_key) { OpenSSL::PKey::RSA.generate(keysize, exponent) } 
+        let_tmp_file(:client_certificate_key_file) { client_certificate_key }
+        let(:client_certificate) do
+          csr = Flores::PKI::CertificateSigningRequest.new
+          csr.start_time = Time.now
+          csr.expire_time = csr.start_time + certificate_duration
+          csr.public_key = client_certificate_key.public_key
+          csr.subject = "CN=localhost"
+          csr.signing_key = root_ca_key
+          csr.signing_certificate = root_ca_certificate
+          csr.want_signature_ability = false
+          csr.create
+        end
+        let_tmp_file(:client_certificate_file) { client_certificate }
+
+        let(:server_certificate_key) { OpenSSL::PKey::RSA.generate(keysize, exponent) } 
+        let(:server_certificate_key_file) { write_to_tmp_file(server_certificate_key) }
+        let(:server_certificate) do
+          csr = Flores::PKI::CertificateSigningRequest.new
+          csr.start_time = Time.now
+          csr.expire_time = csr.start_time + certificate_duration
+          csr.public_key = server_certificate_key.public_key
+          csr.subject = "CN=localhost"
+          csr.signing_key = root_ca_key
+          csr.signing_certificate = root_ca_certificate
+          csr.want_signature_ability = false
+          csr.create
+        end
+        let_tmp_file(:server_certificate_file) { server_certificate }
+
+        let(:options) do
+          super.merge({ :ssl_certificate => client_certificate_file, 
+                        :ssl_certificate_key => client_certificate_key_file, 
+                        :ssl_certificate_authorities => root_ca_certificate_file })
+        end
+
+        let(:config_ssl) do
+          super.merge({ :ssl_certificate_authorities => root_ca_certificate_file,
+                        :ssl_certificate => server_certificate_file,
+                        :ssl_key => server_certificate_key_file, 
+                        :verify_mode => :force_peer })
+        end
+        
         include_examples "transmit payloads"
       end
 
-      context "v1 frame" do
+      # Doesnt work because of this issues in `jruby-openssl`
+      # https://github.com/jruby/jruby-openssl/issues/84
+      xcontext "CA given with client providing intermediate and client certificate" do
+        let(:intermediate_certificate_key) { OpenSSL::PKey::RSA.generate(keysize, exponent) } 
+        let_tmp_file(:intermediate_certificate_key_file) { intermediate_certificate_key }
+        let(:intermediate_certificate) do
+          csr = Flores::PKI::CertificateSigningRequest.new
+          csr.start_time = Time.now
+          csr.expire_time = csr.start_time + certificate_duration
+          csr.public_key = intermediate_certificate_key.public_key
+          csr.subject = "CN=intermediate 1"
+          csr.signing_key = root_ca_key
+          csr.signing_certificate = root_ca_certificate
+          csr.want_signature_ability = true
+          csr.create
+        end
+        let_tmp_file(:intermediate_certificate_file) { intermediate_certificate }
+        let(:client_certificate_key) { OpenSSL::PKey::RSA.generate(keysize, exponent) } 
+        let_tmp_file(:client_certificate_key_file) { client_certificate_key }
+        let(:client_certificate) do
+          csr = Flores::PKI::CertificateSigningRequest.new
+          csr.start_time = Time.now
+          csr.expire_time = csr.start_time + certificate_duration
+          csr.public_key = client_certificate_key.public_key
+          csr.subject = "CN=localhost"
+          csr.signing_key = intermediate_certificate_key
+          csr.signing_certificate = intermediate_certificate
+          csr.want_signature_ability = false
+          csr.create
+        end
+        let_tmp_file(:client_certificate_file) { client_certificate }
+
+        let(:server_certificate_key) { OpenSSL::PKey::RSA.generate(keysize, exponent) } 
+        let_tmp_file(:server_certificate_key_file) { server_certificate_key }
+        let(:server_certificate) do
+          csr = Flores::PKI::CertificateSigningRequest.new
+          csr.start_time = Time.now
+          csr.expire_time = csr.start_time + certificate_duration
+          csr.public_key = server_certificate_key.public_key
+          csr.subject = "CN=localhost"
+          csr.signing_key = intermediate_certificate_key
+          csr.signing_certificate = intermediate_certificate
+          csr.want_signature_ability = false
+          csr.create
+        end
+        let_tmp_file(:server_certificate_file) { server_certificate }
+        let_tmp_file(:certificate_chain_file) { Flores::PKI.chain_certificates(root_ca_certificate, intermediate_certificate) }
+
+        let(:options) do
+          super.merge({ :ssl_certificate => client_certificate_file, 
+                        :ssl_certificate_key => client_certificate_key_file, 
+                        :ssl_certificate_authorities => certificate_chain_file })
+        end
+
+        let(:config_ssl) do
+          super.merge({ :ssl_certificate_authorities => certificate_chain_file,
+                        :ssl_certificate => server_certificate_file,
+                        :ssl_key => server_certificate_key_file, 
+                        :verify_mode => :force_peer })
+
+
+        end
+
         include_examples "transmit payloads"
+      end
+
+      context "Mutiple CA different clients" do
+        let(:secondary_root_ca) { Flores::PKI.generate("CN=secondary.root.logstash") }
+        let(:secondary_root_ca_certificate) { root_ca.first }
+        let(:secondary_root_ca_key) { root_ca.last }
+        let_tmp_file(:secondary_root_ca_certificate_file) { root_ca_certificate }
+
+        let(:secondary_client_certificate_key) { OpenSSL::PKey::RSA.generate(keysize, exponent) } 
+        let(:secondary_client_certificate_key_file) { write_to_tmp_file(secondary_client_certificate_key) }
+        let(:secondary_client_certificate) do
+          csr = Flores::PKI::CertificateSigningRequest.new
+          csr.start_time = Time.now
+          csr.expire_time = csr.start_time + certificate_duration
+          csr.public_key = secondary_client_certificate_key.public_key
+          csr.subject = "CN=localhost"
+          csr.signing_key = secondary_root_ca_key
+          csr.signing_certificate = secondary_root_ca_certificate
+          csr.want_signature_ability = false
+          csr.create
+        end
+        let_tmp_file(:secondary_client_certificate_file) { secondary_client_certificate }
+        let(:client_certificate_key) { OpenSSL::PKey::RSA.generate(keysize, exponent) } 
+        let_tmp_file(:client_certificate_key_file) { client_certificate_key }
+        let(:client_certificate) do
+          csr = Flores::PKI::CertificateSigningRequest.new
+          csr.start_time = Time.now
+          csr.expire_time = csr.start_time + certificate_duration
+          csr.public_key = client_certificate_key.public_key
+          csr.subject = "CN=localhost"
+          csr.signing_key = root_ca_key
+          csr.signing_certificate = root_ca_certificate
+          csr.want_signature_ability = false
+          csr.create
+        end
+        let_tmp_file(:client_certificate_file) { client_certificate }
+
+        let(:server_certificate_key) { OpenSSL::PKey::RSA.generate(keysize, exponent) } 
+        let_tmp_file(:server_certificate_key_file) { server_certificate_key }
+        let(:server_certificate) do
+          csr = Flores::PKI::CertificateSigningRequest.new
+          csr.start_time = Time.now
+          csr.expire_time = csr.start_time + certificate_duration
+          csr.public_key = server_certificate_key.public_key
+          csr.subject = "CN=localhost"
+          csr.signing_key = root_ca_key
+          csr.signing_certificate = root_ca_certificate
+          csr.want_signature_ability = false
+          csr.create
+        end
+        let_tmp_file(:server_certificate_file) { server_certificate }
+
+        shared_examples "multiples client" do
+          context "client from primary CA" do
+            let(:options) do
+              super.merge({ :ssl_certificate => client_certificate_file, 
+                            :ssl_certificate_key => client_certificate_key_file, 
+                            :ssl_certificate_authorities => [root_ca_certificate_file] })
+            end
+
+            include_examples "transmit payloads"
+          end
+
+          context "client from secondary CA" do
+            let(:options) do
+              super.merge({ :ssl_certificate => secondary_client_certificate_file, 
+                            :ssl_certificate_key => secondary_client_certificate_key_file, 
+                            :ssl_certificate_authorities => [root_ca_certificate_file] })
+            end
+
+            include_examples "transmit payloads"
+          end
+        end
+
+        context "when the CA are defined individually in the configuration" do
+          let(:config_ssl) do
+            super.merge({ :ssl_certificate_authorities => [secondary_root_ca_certificate_file, root_ca_certificate_file],
+                          :ssl_certificate => server_certificate_file,
+                          :ssl_key => server_certificate_key_file, 
+                          :verify_mode => "force_peer" })
+          end
+
+          include_examples "multiples client"
+        end
+
+        context "when the CA are defined by a path in the configuration" do
+          let(:ca_path) do
+            p = Stud::Temporary.directory
+            
+            # Doing this here make sure the path is populated when the server
+            # is started in the main before block
+            FileUtils.mkdir_p(p)
+            FileUtils.cp(secondary_root_ca_certificate_file, p)
+            FileUtils.cp(root_ca_certificate_file, p)
+
+            p
+          end
+
+          after :each do
+            FileUtils.rm_rf(ca_path)
+          end
+
+          let(:config_ssl) do
+            super.merge({ :ssl_certificate_authorities => ca_path,
+                          :ssl_certificate => server_certificate_file,
+                          :ssl_key => server_certificate_key_file, 
+                          :verify_mode => "force_peer" })
+          end
+
+          include_examples "multiples client"
+        end
       end
     end
   end

--- a/spec/support/client_process_helpers.rb
+++ b/spec/support/client_process_helpers.rb
@@ -1,0 +1,27 @@
+# encoding: utf-8
+require "childprocess"
+module ClientProcessHelpers
+  def start_client(timeout = 1)
+    @client_out = Stud::Temporary.file
+    @client_out.sync
+
+    @process = ChildProcess.build(*cmd)
+    @process.duplex = true
+    @process.io.stdout = @process.io.stderr = @client_out
+    ChildProcess.posix_spawn = true
+    @process.start
+  end
+
+  def stop_client
+    begin
+      @process.poll_for_exit(5)
+    rescue ChildProcess::TimeoutError
+      @process.stop
+    end
+
+    @client_out.rewind
+
+    # can be used to helper debugging when a test fails
+    @execution_output = @client_out.read
+  end
+end

--- a/spec/support/file_helpers.rb
+++ b/spec/support/file_helpers.rb
@@ -1,0 +1,61 @@
+# encoding: utf-8
+
+# Add an helper method named `let_tmp_file` to spec example, this
+# helper will create a temporary file with the content from the block,
+# it behave like a normal `let` statement. Also to make things easier temporary
+# debug it will create another `let` statement with the actual content of the block.
+#
+# Example:
+# ```
+# let_tmp_file(:hello_world_file) { "Hello world" } # return a path to a tmp file containing "Hello World"
+# and will create this debug `let`, the value of the file will be the same.
+# let(:hello_world_file_content) # return "Hello world"
+#
+module FileHelpers
+  AUTO_CLEAN = true
+
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+
+  def write_to_tmp_file(content)
+    file = Stud::Temporary.file
+    file.write(content.to_s)
+    file.close
+    file.path
+  end
+
+  module ClassMethods
+    def let_empty_tmp_file(name, &block)
+      let(name) do
+        path = nil
+        f = Stud::Temporary.file
+        f.close
+        path = f.path
+        @__let_tmp_files = [] unless @__let_tmp_files
+        @__let_tmp_files << path
+        path
+      end
+    end
+
+    def let_tmp_file(name, &block)
+      after :each do
+        if @__let_tmp_files && FileHelpers::AUTO_CLEAN
+          @__let_tmp_files.each do |f|
+            FileUtils.rm_f(f)
+          end
+        end
+      end
+
+      name_content = "#{name}_content"
+      let(name_content, &block)
+      let(name) do
+        content = __send__(name_content)
+        path = write_to_tmp_file(content)
+        @__let_tmp_files = [] unless @__let_tmp_files
+        @__let_tmp_files << path
+        path
+      end
+    end
+  end
+end

--- a/spec/support/flores_extensions.rb
+++ b/spec/support/flores_extensions.rb
@@ -1,0 +1,42 @@
+# encoding: utf-8
+require "flores/pki"
+module Flores
+  module PKI
+    DEFAULT_CERTIFICATE_OPTIONS = {
+      :duration => Flores::Random.number(100..2000),
+      :key_size => GENERATE_DEFAULT_KEY_SIZE, 
+      :exponent => GENERATE_DEFAULT_EXPONENT,
+      :want_signature_ability => false
+    }
+
+    def self.chain_certificates(*certificates)
+      certificates.join("\n")
+    end
+
+    def self.create_intermediate_certificate(subject, signing_certificate, signing_private_key, options  = {})
+      create_a_signed_certificate(subject, signing_certificate, signing_private_key, options.merge({ :want_signature_ability => true }))
+    end
+
+    def self.create_client_certicate(subject, signing_certificate, signing_private_key, options = {})
+      create_a_signed_certificate(subject, signing_certificate, signing_private_key, options)
+    end
+
+    private
+    def self.create_a_signed_certificate(subject, signing_certificate, signing_private_key, options = {})
+      options = DEFAULT_CERTIFICATE_OPTIONS.merge(options)
+
+      client_key = OpenSSL::PKey::RSA.new(options[:key_size], options[:exponent])
+
+      csr = Flores::PKI::CertificateSigningRequest.new
+      csr.start_time = Time.now
+      csr.expire_time = csr.start_time + options[:duration]
+      csr.public_key = client_key.public_key
+      csr.subject = subject
+      csr.signing_key = signing_private_key
+      csr.signing_certificate = signing_certificate
+      csr.want_signature_ability = options[:want_signature_ability]
+
+      [csr.create, client_key]
+    end
+  end
+end

--- a/spec/support/integration_shared_context.rb
+++ b/spec/support/integration_shared_context.rb
@@ -1,0 +1,55 @@
+# encoding: utf-8
+require "flores/random"
+
+shared_examples "send events" do
+  it "successfully send the events" do
+    expect(queue.size).to eq(number_of_events), "Expected: #{number_of_events} got: #{queue.size}, execution output:\n #{@execution_output}"
+    expect(queue.collect { |e| e["message"] }).to eq(events)
+  end
+end
+
+shared_examples "doesn't send events" do
+  it "doesn't send any events" do
+    expect(queue.size).to eq(0), "Expected: #{number_of_events} got: #{queue.size}, execution output:\n #{@execution_output}"
+  end
+end
+
+shared_context "beats configuration" do
+  # common
+  let(:port) { Flores::Random.integer(1024..65335) }
+  let(:host) { "localhost" }
+
+  let(:queue) { [] }
+  let(:log_file) { write_to_tmp_file(events.join("\n") + "\n") } # make sure we end of line
+  let(:number_of_events) { 5 }
+  let(:event) { "Hello world" }
+  let(:events) do
+    events = []
+    number_of_events.times { |n| events << "#{event} #{n}" }
+    events
+  end
+
+  let(:input_config) do
+    {
+      "host" => host,
+      "port" => port
+    }
+  end
+
+  let(:beats) do
+    LogStash::Inputs::Beats.new(input_config)
+  end
+
+  before :each do
+    beats.register
+
+    @server = Thread.new do
+      beats.run(queue)
+    end
+    @server.abort_on_exception = true
+
+    sleep(1) while @server.status != "run"
+  end
+
+  after(:each) { beats.stop }
+end


### PR DESCRIPTION
This PR introduce client verification when using `ssl`, when using this
option you need to specify the **Certificate Authority** using the
`ssl_certificate_authorities` option, this configuration take a
certificate to validate the client with it. You also need to specify a
`ssl_verify_mode`, If you want strict ssl verification use `force_peer`,
with this value if the client doesn't provide a valid certificate the
plugins will refuse the client.

On Filebeat you need to configure the client to declare a certificate using
theses options.

```
tls:
  certificate_authorities: ["/etc/server.crt"]
  certificate: /etc/server.crt
  certificate_key: /etc/server.key
```

This change also introduce testing with travis-ci and an integration
suite with filebeat for the SSL options.

Fix: #8