### PR TITLE
Fix concurrent-ruby dependencies that broke installation

### DIFF
--- a/logstash-input-beats.gemspec
+++ b/logstash-input-beats.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = "logstash-input-beats"
-  s.version         = '2.2.2'
+  s.version         = '2.2.3'
   s.licenses        = ["Apache License (2.0)"]
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
 
   s.add_runtime_dependency "logstash-codec-plain"
-  s.add_runtime_dependency "concurrent-ruby", "~> 0.9.2"
+  s.add_runtime_dependency "concurrent-ruby", [ ">= 0.9.2", "<= 1.0.0" ]
   s.add_runtime_dependency "thread_safe", "~> 0.3.5"
   s.add_runtime_dependency "logstash-codec-multiline", "~> 2.0.5"
 


### PR DESCRIPTION
In logstash-core we fix the concurrent-ruby version to be `1.0.0`, while in this plugin we had the `~> 0.9.2` constraint, making this actually impossible to be installed in recent master branch. See:

```
skywalker% rake bootstrap
mkdir -p vendor
mkdir vendor/_
Downloading http://jruby.org.s3.amazonaws.com/downloads/1.7.24/jruby-bin-1.7.24.tar.gz
Installing minitar >= 0 because the build process needs it.
[bootstrap] Fetching and installing gem: minitar (>= 0)
Fetching: minitar-0.5.4.gem (100%)
Successfully installed minitar-0.5.4
Installing bundler ~> 1.9.4 because the build process needs it.
[bootstrap] Fetching and installing gem: bundler (~> 1.9.4)
Fetching: bundler-1.9.10.gem (100%)
Successfully installed bundler-1.9.10
Invoking bundler install...
Fetching gem metadata from https://rubygems.org/.........
Fetching version metadata from https://rubygems.org/...
Fetching dependency metadata from https://rubygems.org/..
Resolving dependencies.......
Installing addressable 2.3.8
Installing cabin 0.8.1
Installing arr-pm 0.0.10
Installing backports 3.6.7
Installing ffi 1.9.10
Installing childprocess 0.5.9
Installing numerizer 0.1.1
Installing chronic_duration 0.10.6
Installing clamp 0.6.5
Installing coderay 1.1.1 (was 1.1.0)
Installing concurrent-ruby 1.0.0
... REDACTED ...

   gem 'ruby-maven', '~> 3.3.3'

Building logstash-core-event-java using gradle
:compileJava UP-TO-DATE
:processResources UP-TO-DATE
:classes UP-TO-DATE
:jar UP-TO-DATE
:sourcesJar UP-TO-DATE
:copyGemjar

BUILD SUCCESSFUL

Total time: 6.405 secs

This build could be faster, please consider using the Gradle Daemon: https://docs.gradle.org/2.8/userguide/gradle_daemon.html
skywalker% bin/logstash-plugin install --version 2.2.2 logstash-input-beats
Validating logstash-input-beats-2.2.2
Installing logstash-input-beats
Plugin version conflict, aborting
ERROR: Installation Aborted, message: Bundler could not find compatible versions for gem "concurrent-ruby":
  In snapshot (Gemfile.lock):
    concurrent-ruby (= 1.0.0)

  In Gemfile:
    concurrent-ruby (= 1.0.0) java

    logstash-input-beats (= 2.2.2) java depends on
      concurrent-ruby (~> 0.9.2) java

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

by fixing this constraint to actually be `~> 1.0.0` we enable the pattern to match as expected.

Related to https://github.com/elastic/logstash/issues/4887