### PR TITLE
Make `ssl_key_passphrase` work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2.2.4
+  - Fix bug where using `ssl_key_passphrase` wouldn't work 
 # 2.2.2
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
 # 2.2.1

--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -115,7 +115,7 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
       :ssl => @ssl,
       :ssl_certificate => @ssl_certificate,
       :ssl_key => @ssl_key,
-      :ssl_key_passphrase => @ssl_key_passphrase,
+      :ssl_key_passphrase => @ssl_key_passphrase.value,
       :ssl_certificate_authorities => @ssl_certificate_authorities,
       :ssl_verify_mode => @ssl_verify_mode)
 

--- a/logstash-input-beats.gemspec
+++ b/logstash-input-beats.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = "logstash-input-beats"
-  s.version         = '2.2.3'
+  s.version         = '2.2.4'
   s.licenses        = ["Apache License (2.0)"]
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fix bug where using `ssl_key_passphrase` wouldn't work

Fixes #61