### PR TITLE
Added test and Fix the failling test.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.2.5
+  - Fix failing tests introduce by the `ssl_key_passphrase` changes.
+  - Added an integration test for the `ssl_key_passphrase`
 # 2.2.4
   - Fix bug where using `ssl_key_passphrase` wouldn't work 
 # 2.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.2.5
   - Fix failing tests introduce by the `ssl_key_passphrase` changes.
   - Added an integration test for the `ssl_key_passphrase`
+  - Add an optional parameter for `auto_flush`
 # 2.2.4
   - Fix bug where using `ssl_key_passphrase` wouldn't work 
 # 2.2.2

--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -115,7 +115,7 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
       :ssl => @ssl,
       :ssl_certificate => @ssl_certificate,
       :ssl_key => @ssl_key,
-      :ssl_key_passphrase => @ssl_key_passphrase.value,
+      :ssl_key_passphrase => @ssl_key_passphrase ? @ssl_key_passphrase.value : nil,
       :ssl_certificate_authorities => @ssl_certificate_authorities,
       :ssl_verify_mode => @ssl_verify_mode)
 

--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -36,7 +36,7 @@ class LogStash::Codecs::Base
     end
   end
   if !method_defined?(:auto_flush)
-    def auto_flush
+    def auto_flush(*)
     end
   end
 end

--- a/logstash-input-beats.gemspec
+++ b/logstash-input-beats.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = "logstash-input-beats"
-  s.version         = '2.2.4'
+  s.version         = '2.2.5'
   s.licenses        = ["Apache License (2.0)"]
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This PR add a test for the `ssl_key_passphrase` option, to make sure we
actually pass the right password to the `OpenSSL::X509::Certificate`.

This changes also fix the current build on jenkins https://github.com/logstash-plugins/logstash-input-beats/issues/69