### PR TITLE
Do not use the identity map unless we specify the multiline codec.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2.2.6
+  - Do not use the identity map if we don't explicitly use the `multiline` codec
 # 2.2.5
   - Fix failing tests introduce by the `ssl_key_passphrase` changes.
   - Added an integration test for the `ssl_key_passphrase`

--- a/lib/logstash/inputs/beats_support/decoded_event_transform.rb
+++ b/lib/logstash/inputs/beats_support/decoded_event_transform.rb
@@ -11,7 +11,7 @@ module LogStash::Inputs::BeatsSupport
       event["@timestamp"] = ts unless ts.nil?
       hash.each { |k, v| event[k] = v }
       super(event)
-      event.tag("beats_input_codec_#{@input.codec.base_codec.class.config_name}_applied")
+      event.tag("beats_input_codec_#{codec_name}_applied")
       event
     end
 

--- a/lib/logstash/inputs/beats_support/event_transform_common.rb
+++ b/lib/logstash/inputs/beats_support/event_transform_common.rb
@@ -31,6 +31,14 @@ module LogStash::Inputs::BeatsSupport
       @input.send(:decorate, event)
     end
 
+    def codec_name
+      @codec_name ||= if @input.codec.respond_to?(:base_codec)
+                        @input.codec.base_codec.class.config
+                      else
+                        @input.codec.class.config_name
+                      end
+    end
+
     def transform(event)
       copy_beat_hostname(event)
       decorate(event)

--- a/logstash-input-beats.gemspec
+++ b/logstash-input-beats.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = "logstash-input-beats"
-  s.version         = '2.2.5'
+  s.version         = '2.2.6'
   s.licenses        = ["Apache License (2.0)"]
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
In some case when multiples FB clients are connected to the server and
and watching a lot of files we can hit the limit or the 20K identity
stream. This PR doesnt solve the 20K problems, but changes when the
identity map is used, we will only use it if the multiline codec is
defined in the configuration file. When its not the case the codec will
be reuse accross connection thread. We can do that since our codec are
stateless.

Help with #66 when not using the multiline codec.