### PR TITLE
Fix non deterministic tests with ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2.2.7
+  - More robust test when using a random port #60
 # 2.2.6
   - Do not use the identity map if we don't explicitly use the `multiline` codec
 # 2.2.5

--- a/logstash-input-beats.gemspec
+++ b/logstash-input-beats.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = "logstash-input-beats"
-  s.version         = '2.2.6'
+  s.version         = '2.2.7'
   s.licenses        = ["Apache License (2.0)"]
   s.summary         = "Receive events using the lumberjack protocol."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -30,8 +30,8 @@ describe "A client" do
     p.close
     p.path
   end
-  let(:port) { Flores::Random.integer(1024..65335) }
-  let(:tcp_port) { port + 1 }
+  let(:port) { Flores::Random.port }
+  let(:tcp_port) { Flores::Random.port }
   let(:host) { "127.0.0.1" }
   let(:queue) { [] }
   let(:config_ssl) do

--- a/spec/lumberjack/beats/client_spec.rb
+++ b/spec/lumberjack/beats/client_spec.rb
@@ -11,7 +11,7 @@ require "zlib"
 
 describe Lumberjack::Beats::Client do
   describe Lumberjack::Beats::Socket do
-    let(:port)   { 5000 }
+    let(:port) { Flores::Random.port }
 
     subject(:socket) { Lumberjack::Beats::Socket.new(:port => port, :ssl_certificate => "" ) }
 

--- a/spec/lumberjack/beats/connection_spec.rb
+++ b/spec/lumberjack/beats/connection_spec.rb
@@ -5,7 +5,7 @@ require "flores/random"
 
 describe "Connnection" do
   let(:ip) { "192.168.1.2" }
-  let(:port) { 4444 }
+  let(:port) { Flores::Random.port }
   let(:server) { double("server", :closed? => false) }
   let(:socket) { double("socket", :closed? => false) }
   let(:connection) { Lumberjack::Beats::Connection.new(socket, server) }

--- a/spec/lumberjack/beats/server_spec.rb
+++ b/spec/lumberjack/beats/server_spec.rb
@@ -4,6 +4,7 @@ require "lumberjack/beats/server"
 require "flores/random"
 require "flores/pki"
 require "spec_helper"
+require_relative "../../support/flores_extensions"
 
 Thread.abort_on_exception = true
 
@@ -11,8 +12,8 @@ describe "Server" do
   let(:certificate) { Flores::PKI.generate }
   let(:certificate_file_crt) { "certificate.crt" }
   let(:certificate_file_key) { "certificate.key" }
-  let(:port) { Flores::Random.integer(1024..65335) }
-  let(:tcp_port) { port + 1 }
+  let(:port) { Flores::Random.port }
+  let(:tcp_port) { Flores::Random.port }
   let(:host) { "127.0.0.1" }
   let(:queue) { [] }
 

--- a/spec/support/integration_shared_context.rb
+++ b/spec/support/integration_shared_context.rb
@@ -16,7 +16,7 @@ end
 
 shared_context "beats configuration" do
   # common
-  let(:port) { Flores::Random.integer(1024..65335) }
+  let(:port) { Flores::Random.port }
   let(:host) { "localhost" }
 
   let(:queue) { [] }

--- a/spec/support/integration_shared_context.rb
+++ b/spec/support/integration_shared_context.rb
@@ -44,7 +44,11 @@ shared_context "beats configuration" do
     beats.register
 
     @server = Thread.new do
-      beats.run(queue)
+      begin
+        beats.run(queue)
+      rescue
+        retry unless beats.stop?
+      end
     end
     @server.abort_on_exception = true
 


### PR DESCRIPTION
Instead of just using a random number from a range, The
`Flores::Random.port` will try to setup a server on the specific port,
if everything is fine it will close the server and give you the port
number to use and we will know for sure that the port can be used.
The helper will try multiple port before giving up completely. (15
times)

This PR also make sure that all the tests are using random ports.

fixes #60