### PR TITLE
Fix/lsf integration fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # 2.2.8
   - Fix #73 Bug in EventTransformCommon#codec_name, use config_name
-  - add regression test for fix to 73
-  - non deterministic error for the LSF integration test
+  - Add regression test for fix to #73
+  - Non deterministic error for the LSF integration test
+  - Make this plugin really a drop in replacement for the lumberjack input, so LSF can send their events to this plugin.
 # 2.2.7
   - More robust test when using a random port #60
   - Fix LSF integration tests #52

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.2.8
   - Fix #73 Bug in EventTransformCommon#codec_name, use config_name
   - add regression test for fix to 73
+  - non deterministic error for the LSF integration test
 # 2.2.7
   - More robust test when using a random port #60
   - Fix LSF integration tests #52

--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -95,7 +95,7 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
   config :congestion_threshold, :validate => :number, :default => 5
 
   # This is the default field that the specified codec will be applied
-  config :target_field_for_codec, :validate => :string, :default => "message"
+  config :target_field_for_codec, :validate => :string, :default => "message", :deprecated => "This option is now deprecated, the plugin is now compatible with Filebeat and Logstash-Forwarder"
 
   # TODO(sissel): Add CA to authenticate clients with.
   RECONNECT_BACKOFF_SLEEP = 0.5

--- a/lib/logstash/inputs/beats_support/decoded_event_transform.rb
+++ b/lib/logstash/inputs/beats_support/decoded_event_transform.rb
@@ -9,7 +9,11 @@ module LogStash::Inputs::BeatsSupport
       ts = coerce_ts(hash.delete("@timestamp"))
 
       event["@timestamp"] = ts unless ts.nil?
-      hash.each { |k, v| event[k] = v }
+      hash.each do |k, v|
+        # LSF doesn't always return utf-8 values
+        v = v.force_encoding(Encoding::UTF_8)
+        event[k] = v
+      end
       super(event)
       event.tag("beats_input_codec_#{codec_name}_applied")
       event

--- a/lib/logstash/inputs/beats_support/decoded_event_transform.rb
+++ b/lib/logstash/inputs/beats_support/decoded_event_transform.rb
@@ -9,11 +9,7 @@ module LogStash::Inputs::BeatsSupport
       ts = coerce_ts(hash.delete("@timestamp"))
 
       event["@timestamp"] = ts unless ts.nil?
-      hash.each do |k, v|
-        # LSF doesn't always return utf-8 values
-        v = v.force_encoding(Encoding::UTF_8)
-        event[k] = v
-      end
+      hash.each { |k, v| event[k] = v }
       super(event)
       event.tag("beats_input_codec_#{codec_name}_applied")
       event

--- a/lib/lumberjack/beats.rb
+++ b/lib/lumberjack/beats.rb
@@ -1,6 +1,8 @@
 # encoding: utf-8
 require "json"
 module Lumberjack module Beats
+  FILEBEAT_LOG_LINE_FIELD = "message".freeze
+  LSF_LOG_LINE_FIELD = "line".freeze
   SEQUENCE_MAX = (2**32-1).freeze
 
   @@json = Class.new do

--- a/lib/lumberjack/beats/server.rb
+++ b/lib/lumberjack/beats/server.rb
@@ -467,7 +467,7 @@ module Lumberjack module Beats
           reset_next_ack(*args)
         when :data
           sequence, map = args
-          ack_if_needed(sequence) { data(map, &block) }
+          ack_if_needed(sequence) { data(normalize_v1_metadata_encoding(map), &block) }
         when :json
           # If the payload is an array of items we will emit multiple events
           # this behavior was moved from the plugin to the library.
@@ -483,6 +483,14 @@ module Lumberjack module Beats
           end
         end
       end
+    end
+
+    def normalize_v1_metadata_encoding(map)
+      # lets normalize the metadata of the v1 frame to make
+      # sure everything is utf-8 minus the content itself.
+      # We need this to make this plugin backward compatible.
+      map.each { |k, v| map[k].force_encoding(Encoding::UTF_8) unless k == "line" }
+      map
     end
 
     def version(version)

--- a/lib/lumberjack/beats/server.rb
+++ b/lib/lumberjack/beats/server.rb
@@ -487,9 +487,10 @@ module Lumberjack module Beats
 
     def normalize_v1_metadata_encoding(map)
       # lets normalize the metadata of the v1 frame to make
-      # sure everything is utf-8 minus the content itself.
-      # We need this to make this plugin backward compatible.
-      map.each { |k, v| map[k].force_encoding(Encoding::UTF_8) unless k == "line" }
+      # sure everything is in utf-8 format, because LSF don't enforce the encoding when he send
+      # the data to the server. Path, offset can be in another encoding, when the data is assigned to the event.
+      # the event will validate it and crash when the encoding is in the wrong format.
+      map.each { |k, v| map[k].force_encoding(Encoding::UTF_8) unless k == Lumberjack::Beats::LSF_LOG_LINE_FIELD }
       map
     end
 

--- a/spec/integration/logstash_forwarder_spec.rb
+++ b/spec/integration/logstash_forwarder_spec.rb
@@ -19,9 +19,10 @@ describe "Logstash-Forwarder", :integration => true do
     end
   end
 
-  let(:client_wait_time) { 5 }
   include FileHelpers
   include_context "beats configuration"
+
+  let(:client_wait_time) { 5 }
 
   # Filebeat related variables
   let(:cmd) { [lsf_exec, "-config", lsf_config_path] }
@@ -53,6 +54,7 @@ describe "Logstash-Forwarder", :integration => true do
     File.open(log_file, "a") do |f|
       f.write(events.join("\n") + "\n")
     end
+    sleep(1) # give some time to the clients to pick up the changes
   end
 
   after :each do

--- a/spec/integration/logstash_forwarder_spec.rb
+++ b/spec/integration/logstash_forwarder_spec.rb
@@ -78,7 +78,6 @@ describe "Logstash-Forwarder", :integration => true do
           "ssl" => true,
           "ssl_certificate" => certificate_file,
           "ssl_key" => certificate_key_file,
-          "target_field_for_codec" => "line"
         })
       end
 

--- a/spec/support/integration_shared_context.rb
+++ b/spec/support/integration_shared_context.rb
@@ -48,12 +48,14 @@ shared_context "beats configuration" do
 
     @server = Thread.new do
       begin
-        # This is used for debugging
-        #
-        # logger = Logger.new(STDOUT)
-        # beats.logger = Cabin::Channel.new
-        # beats.logger.subscribe(logger)
-        # beats.logger.level = :debug
+        # use to know what lumberjack is actually doing
+        if ENV["DEBUG"]
+          logger = Logger.new(STDOUT)
+          beats.logger = Cabin::Channel.new
+          beats.logger.subscribe(logger)
+          beats.logger.level = :debug
+        end
+
         beats.run(queue)
       rescue => e
         retry unless beats.stop?


### PR DESCRIPTION
This was a nasty bug, I did not have it all the time, It might be related to the jruby version I was running at the time I created the tests.

The problem was the following, LSF metadata doesn't have the right encoding and was making the server thread crash. You can see it by enabling `DEBUG` when running the integration test.

This PR also make sure the plugin is a drop in replacement for lumberjack, since the hash send by LSF and filebeat are a bit different.