### PR TITLE
SSL Handshake Timeout

### DIFF
--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -86,6 +86,9 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
   # This option needs to be used with `ssl_certificate_authorities` and a defined list of CAs.
   config :ssl_verify_mode, :validate => ["none", "peer", "force_peer"], :default => "none"
 
+  # Time in milliseconds for an incomplete ssl handshake to timeout
+  config :ssl_handshake_timeout, :validate => :number, :default => 10000
+
   # The number of seconds before we raise a timeout. 
   # This option is useful to control how much time to wait if something is blocking the pipeline.
   config :congestion_threshold, :validate => :number, :default => 5
@@ -134,11 +137,12 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
         .setProtocols(convert_protocols)
         .setCipherSuites(normalized_ciphers)
 
+      ssl_builder.setHandshakeTimeoutMilliseconds(@ssl_handshake_timeout)
+
       if client_authentification?
         if @ssl_verify_mode.upcase == "FORCE_PEER"
             ssl_builder.setVerifyMode(org.logstash.netty.SslSimpleBuilder::SslClientVerifyMode::FORCE_PEER)
         end
-
         ssl_builder.setCertificateAuthorities(@ssl_certificate_authorities)
       end
 

--- a/src/main/java/org/logstash/beats/Runner.java
+++ b/src/main/java/org/logstash/beats/Runner.java
@@ -38,7 +38,9 @@ public class Runner {
 //            SslSimpleBuilder sslBuilder = new SslSimpleBuilder(sslCertificate, sslKey, null)
             SslSimpleBuilder sslBuilder = new SslSimpleBuilder(new FileInputStream(sslCertificate), converter.convert(), null)
                     .setProtocols(new String[] { "TLSv1.2" })
-                    .setCertificateAuthorities(certificateAuthorities);
+                    .setCertificateAuthorities(certificateAuthorities)
+                    .setHandshakeTimeoutMilliseconds(10000);
+
             server.enableSSL(sslBuilder);
         }
 

--- a/src/main/java/org/logstash/netty/SslSimpleBuilder.java
+++ b/src/main/java/org/logstash/netty/SslSimpleBuilder.java
@@ -23,16 +23,19 @@ import java.util.Arrays;
  * Created by ph on 2016-05-27.
  */
 public class SslSimpleBuilder {
+
+
     public static enum SslClientVerifyMode {
         VERIFY_PEER,
         FORCE_PEER,
     }
     public static Logger logger = LogManager.getLogger(SslSimpleBuilder.class.getName());
 
-
     private InputStream sslKeyFile;
     private InputStream sslCertificateFile;
     private SslClientVerifyMode verifyMode = SslClientVerifyMode.FORCE_PEER;
+
+    private long handshakeTimeoutMilliseconds = 10000;
 
     /*
     Mordern Ciphers List from
@@ -79,6 +82,11 @@ public class SslSimpleBuilder {
 
     public SslSimpleBuilder setCertificateAuthorities(String[] cert) {
         certificateAuthorities = cert;
+        return this;
+    }
+
+    public SslSimpleBuilder setHandshakeTimeoutMilliseconds(int timeout) {
+        handshakeTimeoutMilliseconds = timeout;
         return this;
     }
 
@@ -132,6 +140,8 @@ public class SslSimpleBuilder {
                 engine.setWantClientAuth(true);
             }
         }
+
+        sslHandler.setHandshakeTimeoutMillis(handshakeTimeoutMilliseconds);
 
         return sslHandler;
     }


### PR DESCRIPTION
SSL Handshake from client can sometime be stuck forever this PR expose
the internal netty ssl handler timeout and allow users to configure it.

By default Netty will close any stuck handshake that goes over 10000
milliseconds.

Fixes #101