### PR TITLE
Gracefully recover from sending malformed dataframe

### DIFF
--- a/src/main/java/org/logstash/beats/BeatsHandler.java
+++ b/src/main/java/org/logstash/beats/BeatsHandler.java
@@ -58,7 +58,7 @@ public class BeatsHandler extends SimpleChannelInboundHandler<Batch> {
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         messageListener.onException(ctx);
-        logger.error("Exception", cause);
+        logger.error("Exception: {}", cause.getMessage());
         ctx.close();
     }
 

--- a/src/main/java/org/logstash/beats/BeatsParser.java
+++ b/src/main/java/org/logstash/beats/BeatsParser.java
@@ -230,12 +230,6 @@ public class BeatsParser extends ByteToMessageDecoder {
         batch = new Batch();
     }
 
-    @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-        logger.error("Exception: {}", cause.getMessage());
-        ctx.close();
-    }
-
     public class InvalidFrameProtocol extends Exception {
         public InvalidFrameProtocol(byte frameType) {
             super("Invalid Frame Protocol, Received: " + frameType);

--- a/src/main/java/org/logstash/beats/BeatsParser.java
+++ b/src/main/java/org/logstash/beats/BeatsParser.java
@@ -92,7 +92,7 @@ public class BeatsParser extends ByteToMessageDecoder {
                         break;
                     }
                     default: {
-                        throw new InvalidFrameProtocol(frameType);
+                        throw new InvalidFrameProtocolException("Invalid Frame Type, received: " +frameType);
                     }
                 }
                 break;
@@ -121,6 +121,10 @@ public class BeatsParser extends ByteToMessageDecoder {
                 sequence = (int) in.readUnsignedInt();
                 int fieldsCount = (int) in.readUnsignedInt();
                 int count = 0;
+
+                if(fieldsCount <= 0) {
+                    throw new InvalidFrameProtocolException("Invalid number of fields, received: " + fieldsCount);
+                }
 
                 Map dataMap = new HashMap<String, String>(fieldsCount);
 
@@ -157,6 +161,10 @@ public class BeatsParser extends ByteToMessageDecoder {
 
                 sequence = (int) in.readUnsignedInt();
                 int jsonPayloadSize = (int) in.readUnsignedInt();
+
+                if(jsonPayloadSize <= 0) {
+                    throw new InvalidFrameProtocolException("Invalid json length, received: " + jsonPayloadSize);
+                }
 
                 transition(States.READ_JSON, jsonPayloadSize);
                 break;
@@ -230,9 +238,10 @@ public class BeatsParser extends ByteToMessageDecoder {
         batch = new Batch();
     }
 
-    public class InvalidFrameProtocol extends Exception {
-        public InvalidFrameProtocol(byte frameType) {
-            super("Invalid Frame Protocol, Received: " + frameType);
+    public class InvalidFrameProtocolException extends Exception {
+        InvalidFrameProtocolException(String message) {
+            super(message);
         }
     }
+
 }

--- a/src/main/java/org/logstash/beats/Server.java
+++ b/src/main/java/org/logstash/beats/Server.java
@@ -10,15 +10,12 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateHandler;
-import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import io.netty.util.concurrent.EventExecutorGroup;
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import io.netty.util.concurrent.Future;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.logstash.netty.SslSimpleBuilder;
-
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
@@ -35,7 +32,6 @@ public class Server {
     private final int port;
     private final NioEventLoopGroup bossGroup;
     private final NioEventLoopGroup workGroup;
-
     private IMessageListener messageListener = new MessageListener();
     private SslSimpleBuilder sslBuilder;
 
@@ -106,6 +102,7 @@ public class Server {
         private final String KEEP_ALIVE_HANDLER = "keep-alive-handler";
         private final String BEATS_PARSER = "beats-parser";
         private final String BEATS_HANDLER = "beats-handler";
+        private final String BEATS_ACKER = "beats-acker";
 
         private final int DEFAULT_IDLESTATEHANDLER_THREAD = 4;
         private final int IDLESTATE_WRITER_IDLE_TIME_SECONDS = 5;
@@ -115,6 +112,7 @@ public class Server {
         private final BeatsHandler beatsHandler;
         private final IdleStateHandler idleStateHandler;
         private final LoggingHandler loggingHandler = new LoggingHandler();
+
 
         private boolean enableSSL = false;
 
@@ -137,10 +135,11 @@ public class Server {
 
             // We have set a specific executor for the idle check, because the `beatsHandler` can be
             // blocked on the queue, this the idleStateHandler manage the `KeepAlive` signal.
-            pipeline.addLast(idleExecutorGroup, KEEP_ALIVE_HANDLER, idleStateHandler);
+            pipeline.addLast(idleExecutorGroup, KEEP_ALIVE_HANDLER, idleStateHandler); 
             pipeline.addLast(BEATS_PARSER, new BeatsParser());
-            pipeline.addLast("acker", new AckEncoder());
+            pipeline.addLast(BEATS_ACKER, new AckEncoder());
             pipeline.addLast(BEATS_HANDLER, beatsHandler);
+
         }
 
         public void shutdownEventExecutor() {

--- a/src/test/java/org/logstash/beats/BeatsParserTest.java
+++ b/src/test/java/org/logstash/beats/BeatsParserTest.java
@@ -1,5 +1,6 @@
 package org.logstash.beats;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -8,6 +9,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
@@ -60,6 +62,25 @@ public class BeatsParserTest {
     }
 
     @Test
+    public void testEncodingDecodingFieldWithUTFCharacters() {
+        this.batch = new Batch();
+        this.batch.setProtocol(Protocol.VERSION_2);
+
+        // Generate Data with Keys and String with UTF-8
+        for(int i = 0; i < numberOfMessage; i++) {
+            Map map = new HashMap<String, String>();
+            map.put("étoile", "mystère");
+            map.put("from", "ÉeèAççï");
+
+            Message message = new Message(i + 1, map);
+            this.batch.addMessage(message);
+        }
+
+        Batch decodedBatch = decodeBatch();
+        assertMessages(this.batch, decodedBatch);
+    }
+
+    @Test
     public void testCompressedEncodingDecodingFields() {
         this.batch.setProtocol(Protocol.VERSION_1);
         Batch decodedBatch = decodeCompressedBatch();
@@ -68,13 +89,86 @@ public class BeatsParserTest {
 
     @Test
     public void testShouldNotCrashOnGarbageData() {
+        thrown.expectCause(isA(BeatsParser.InvalidFrameProtocolException.class));
+
         byte[] n = new byte[10000];
         new Random().nextBytes(n);
         ByteBuf randomBufferData = Unpooled.wrappedBuffer(n);
 
-        thrown.expectCause(isA(BeatsParser.InvalidFrameProtocol.class));
+        sendPayloadToParser(randomBufferData);
+    }
+
+
+    @Test
+    public void testNegativeJsonPayloadShouldRaiseAnException() throws JsonProcessingException {
+        sendInvalidJSonPayload(-1);
+    }
+
+    @Test
+    public void testZeroSizeJsonPayloadShouldRaiseAnException() throws JsonProcessingException {
+        sendInvalidJSonPayload(0);
+    }
+
+    @Test
+    public void testNegativeFieldsCountShouldRaiseAnException() {
+        sendInvalidV1Payload(-1);
+    }
+
+    @Test
+    public void testZeroFieldsCountShouldRaiseAnException() {
+        sendInvalidV1Payload(0);
+    }
+
+    private void sendInvalidV1Payload(int size) {
+        thrown.expectCause(isA(BeatsParser.InvalidFrameProtocolException.class));
+        thrown.expectMessage("Invalid number of fields, received: " + size);
+
+        ByteBuf payload = Unpooled.buffer();
+
+        payload.writeByte(Protocol.VERSION_1);
+        payload.writeByte('W');
+        payload.writeInt(1);
+        payload.writeByte(Protocol.VERSION_1);
+        payload.writeByte('D');
+        payload.writeInt(1);
+        payload.writeInt(size);
+
+        byte[] key = "message".getBytes();
+        byte[] value = "Hola".getBytes();
+
+        payload.writeInt(key.length);
+        payload.writeBytes(key);
+        payload.writeInt(value.length);
+        payload.writeBytes(value);
+
+        sendPayloadToParser(payload);
+    }
+
+    private void sendInvalidJSonPayload(int size) throws JsonProcessingException {
+        thrown.expectCause(isA(BeatsParser.InvalidFrameProtocolException.class));
+        thrown.expectMessage("Invalid json length, received: " + size);
+
+        Map mapData = Collections.singletonMap("message", "hola");
+
+        ByteBuf payload = Unpooled.buffer();
+
+        payload.writeByte(Protocol.VERSION_2);
+        payload.writeByte('W');
+        payload.writeInt(1);
+        payload.writeByte(Protocol.VERSION_2);
+        payload.writeByte('J');
+        payload.writeInt(1);
+        payload.writeInt(size);
+
+        byte[] json = BeatsParser.MAPPER.writeValueAsBytes(mapData);
+        payload.writeBytes(json);
+
+        sendPayloadToParser(payload);
+    }
+
+    private void sendPayloadToParser(ByteBuf payload) {
         EmbeddedChannel channel = new EmbeddedChannel(new BeatsParser());
-        channel.writeOutbound(randomBufferData);
+        channel.writeOutbound(payload);
         Object o = channel.readOutbound();
         channel.writeInbound(o);
     }
@@ -85,8 +179,19 @@ public class BeatsParserTest {
 
         for(int i=0; i < expected.size(); i++) {
             assertEquals(expected.getMessages().get(i).getSequence(), actual.getMessages().get(i).getSequence());
-            assertEquals(expected.getMessages().get(i).getData().get("line"), actual.getMessages().get(i).getData().get("line"));
-            assertEquals(expected.getMessages().get(i).getData().get("from"), actual.getMessages().get(i).getData().get("from"));
+
+            Map expectedData = expected.getMessages().get(i).getData();
+            Map actualData = actual.getMessages().get(i).getData();
+
+            assertEquals(expectedData.size(), actualData.size());
+
+            for(Object entry : expectedData.entrySet()) {
+                Map.Entry e = (Map.Entry) entry;
+                String key = (String) e.getKey();
+                String value = (String) e.getValue();
+
+                assertEquals(value, actualData.get(key));
+            }
         }
     }
 

--- a/src/test/java/org/logstash/beats/BeatsParserTest.java
+++ b/src/test/java/org/logstash/beats/BeatsParserTest.java
@@ -4,19 +4,25 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
+import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 
 public class BeatsParserTest {
     private Batch batch;
-        private final int numberOfMessage = 20;
+    private final int numberOfMessage = 20;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
 
     @Before
@@ -66,6 +72,7 @@ public class BeatsParserTest {
         new Random().nextBytes(n);
         ByteBuf randomBufferData = Unpooled.wrappedBuffer(n);
 
+        thrown.expectCause(isA(BeatsParser.InvalidFrameProtocol.class));
         EmbeddedChannel channel = new EmbeddedChannel(new BeatsParser());
         channel.writeOutbound(randomBufferData);
         Object o = channel.readOutbound();


### PR DESCRIPTION
This change make sure the state machien correctly recover from sending
garbage data over the write. The current strategy is to check to make
sure the frametype are correctly send if we received an unknown frame
type we will assume that the frame is poisonous, we will raise a custom
exception `InvalidFrameProtocol` with the associated bytes and will
terminate the connection since we cannot do anything with it.

The BeatsParser will now raise an exception when we receive an invalid size for the json payload (v2) or the fieldcounts (v1)


Fixes: #100 #99