### PR TITLE
Close idle client connection

### DIFF
--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -104,6 +104,9 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
   # The list of ciphers suite to use, listed by priorities.
   config :cipher_suites, :validate => :array, :default => org.logstash.netty.SslSimpleBuilder::DEFAULT_CIPHERS
 
+  # Close Idle clients after X seconds of inactivity.
+  config :client_inactivity_timeout, :validate => :number, :default => 15
+
   def register
     if !@ssl
       @logger.warn("Beats input: SSL Certificate will not be used") unless @ssl_certificate.nil?

--- a/src/main/java/org/logstash/beats/Server.java
+++ b/src/main/java/org/logstash/beats/Server.java
@@ -16,6 +16,9 @@ import io.netty.util.concurrent.Future;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.logstash.netty.SslSimpleBuilder;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
@@ -26,18 +29,25 @@ import java.util.concurrent.TimeUnit;
 public class Server {
     static final Logger logger = LogManager.getLogger(Server.class.getName());
     static final long SHUTDOWN_TIMEOUT_SECONDS = 10;
+    private static final int DEFAULT_CLIENT_TIMEOUT_SECONDS = 15;
 
-    private int port;
 
-    private NioEventLoopGroup bossGroup;
-    private NioEventLoopGroup workGroup;
+    private final int port;
+    private final NioEventLoopGroup bossGroup;
+    private final NioEventLoopGroup workGroup;
+
     private IMessageListener messageListener = new MessageListener();
     private SslSimpleBuilder sslBuilder;
 
-    private int clientInactivityTimeoutSeconds = 15;
+    private final int clientInactivityTimeoutSeconds;
 
     public Server(int p) {
+        this(p, DEFAULT_CLIENT_TIMEOUT_SECONDS);
+    }
+
+    public Server(int p, int timeout) {
         port = p;
+        clientInactivityTimeoutSeconds = timeout;
         bossGroup = new NioEventLoopGroup();
         workGroup = new NioEventLoopGroup();
     }
@@ -69,10 +79,6 @@ public class Server {
         }
 
         return this;
-    }
-
-    public void setClientInactivityTimeout(int time) {
-        clientInactivityTimeoutSeconds = time;
     }
 
     public void stop() throws InterruptedException {

--- a/src/test/java/org/logstash/beats/ServerTest.java
+++ b/src/test/java/org/logstash/beats/ServerTest.java
@@ -10,9 +10,11 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 import org.junit.Before;
 import org.junit.Test;
 import java.util.concurrent.ThreadLocalRandom;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
+import static org.hamcrest.number.IsCloseTo.closeTo;
+
 
 public class ServerTest {
     private int randomPort;
@@ -25,8 +27,8 @@ public class ServerTest {
     public void testServerShouldTerminateConnectionIdleForTooLong() throws InterruptedException {
         int inactivityTime = 3; // in seconds
 
-        Server server = new Server(randomPort);
-        server.setClientInactivityTimeout(inactivityTime);
+        Server server = new Server(randomPort, inactivityTime);
+
 
         Runnable serverTask = () -> {
             try {
@@ -59,8 +61,9 @@ public class ServerTest {
 
             Long ended = System.currentTimeMillis() / 1000L;
 
-            int diff = (int) (ended - started);
-            assertThat(diff, is(greaterThanOrEqualTo(inactivityTime)));
+            double diff = ended - started;
+            assertThat(diff, is(closeTo(inactivityTime, 0)));
+
         } finally {
             group.shutdownGracefully();
             server.stop();

--- a/src/test/java/org/logstash/beats/ServerTest.java
+++ b/src/test/java/org/logstash/beats/ServerTest.java
@@ -1,0 +1,69 @@
+package org.logstash.beats;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import org.junit.Before;
+import org.junit.Test;
+import java.util.concurrent.ThreadLocalRandom;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
+
+public class ServerTest {
+    private int randomPort;
+    @Before
+    public void setUp() {
+        randomPort = ThreadLocalRandom.current().nextInt(1024, 65535);
+    }
+
+    @Test
+    public void testServerShouldTerminateConnectionIdleForTooLong() throws InterruptedException {
+        int inactivityTime = 3; // in seconds
+
+        Server server = new Server(randomPort);
+        server.setClientInactivityTimeout(inactivityTime);
+
+        Runnable serverTask = () -> {
+            try {
+                server.listen();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        };
+
+        Thread thread = new Thread(serverTask);
+        thread.start();
+
+        EventLoopGroup group = new NioEventLoopGroup();
+
+        try {
+            Bootstrap b = new Bootstrap();
+            b.group(group)
+                    .channel(NioSocketChannel.class)
+                    .handler(new ChannelInitializer<SocketChannel>() {
+                                 @Override
+                                 public void initChannel(SocketChannel ch) throws Exception {
+                                 }
+                             }
+                    );
+
+            Long started = System.currentTimeMillis() / 1000L;
+
+            ChannelFuture f = b.connect("localhost", randomPort).sync();
+            f.channel().closeFuture().sync();
+
+            Long ended = System.currentTimeMillis() / 1000L;
+
+            int diff = (int) (ended - started);
+            assertThat(diff, is(greaterThanOrEqualTo(inactivityTime)));
+        } finally {
+            group.shutdownGracefully();
+            server.stop();
+        }
+    }
+}

--- a/src/test/java/org/logstash/beats/ServerTest.java
+++ b/src/test/java/org/logstash/beats/ServerTest.java
@@ -62,7 +62,7 @@ public class ServerTest {
             Long ended = System.currentTimeMillis() / 1000L;
 
             double diff = ended - started;
-            assertThat(diff, is(closeTo(inactivityTime, 0)));
+            assertThat(diff, is(closeTo(inactivityTime, 0.1)));
 
         } finally {
             group.shutdownGracefully();


### PR DESCRIPTION
The server will close the client connection after a certain amount of
activity, the default is 15 seconds but users can configure it at the
plugin level by setting the `client_inactivity_timeout` option to the desired
value.

Doing this will ensure that unterminated connection wont make logstash
run out of FD.

Fixes: #74