### PR TITLE
Update protocol spec to align with implementation

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -9,7 +9,7 @@ The needs that lead to this protocol are:
 
 ## Implementation Considerations
 
-# Lumberjack Protocol v1
+# Lumberjack Protocol v2
 
 ## Behavior
 
@@ -38,10 +38,12 @@ This entire protocol is built to be layered on top of TCP or TLS.
       0                   1                   2                   3
       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
      +---------------+---------------+-------------------------------+
-     |   version(1)  |   frame type  |     payload ...               |
+     |   version     |   frame type  |     payload ...               |
      +---------------------------------------------------------------+
      |   payload continued...                                        |
      +---------------------------------------------------------------+
+
+Version is the protocol version in ASCII (0x32 for protocol version 2)
 
 ### 'data' frame type
 
@@ -94,6 +96,7 @@ mean you are acknowledging all data frames before and including '6'.
 
 * SENT FROM WRITER ONLY
 * frame type value: ASCII 'W' aka byte value 0x57
+* Window frame must be set for each new window.  So with a window frame of 1 the window frame must be set before each data frame.
 
 Payload:
 


### PR DESCRIPTION
The following pull updates the protocol spec with the following changes:
- Update version to 2 as the JSON frame is a v2 improvement per https://discuss.elastic.co/t/logstash-beats-input-lumberjack-protocol-v1-support-lifetime/56334
- Note that the version byte is ASCII per https://github.com/logstash-plugins/logstash-input-beats/blob/a2ad0ea45c5edf69828518d4fc82a22b2817e403/lib/lumberjack/beats/server.rb#L219-L220
- Note that the window frame size needs to be set before each frame of messages, found by troubleshooting reset_next_ack() errors while implementing the spec.

Not sure if the CLA is required for simple documentation fixes, so please let me know if it is.  Thanks.
