### PR TITLE
Add configuration option to disable codec tagging

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,6 +10,7 @@ Contributors:
 * Richard Pijnenburg (electrical)
 * Suyog Rao (suyograo)
 * Guy Boertje (guyboertje)
+* Ian Cordasco (sigmavirus24)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -86,6 +86,8 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
   # This option needs to be used with `ssl_certificate_authorities` and a defined list of CAs.
   config :ssl_verify_mode, :validate => ["none", "peer", "force_peer"], :default => "none"
 
+  config :include_codec_tag, :validate => :boolean, :default => true
+
   # Time in milliseconds for an incomplete ssl handshake to timeout
   config :ssl_handshake_timeout, :validate => :number, :default => 10000
 

--- a/lib/logstash/inputs/beats/decoded_event_transform.rb
+++ b/lib/logstash/inputs/beats/decoded_event_transform.rb
@@ -11,7 +11,7 @@ module LogStash module Inputs class Beats
       event.set("@timestamp", ts) unless ts.nil?
       hash.each { |k, v| event.set(k, v) }
       super(event)
-      event.tag("beats_input_codec_#{codec_name}_applied")
+      event.tag("beats_input_codec_#{codec_name}_applied") if include_codec_tag?
       event
     end
 

--- a/lib/logstash/inputs/beats/event_transform_common.rb
+++ b/lib/logstash/inputs/beats/event_transform_common.rb
@@ -44,5 +44,9 @@ module LogStash module Inputs class Beats
       decorate(event)
       event
     end
+
+    def include_codec_tag?
+      @input.include_codec_tag
+    end
   end
 end; end; end

--- a/lib/logstash/inputs/beats/raw_event_transform.rb
+++ b/lib/logstash/inputs/beats/raw_event_transform.rb
@@ -11,7 +11,7 @@ module LogStash module Inputs class Beats
   class RawEventTransform < EventTransformCommon
     def transform(event)
       super(event)
-      event.tag("beats_input_raw_event")
+      event.tag("beats_input_raw_event") if include_codec_tag?
       event
     end
   end

--- a/spec/inputs/beats/decoded_event_transform_spec.rb
+++ b/spec/inputs/beats/decoded_event_transform_spec.rb
@@ -71,4 +71,11 @@ describe LogStash::Inputs::Beats::DecodedEventTransform do
       expect(subject.get("tags")).to include("beats_input_codec_dummy_applied")
     end
   end
+
+  context "when configured to not include codec tag" do
+    before { config.update("include_codec_tag" => false) }
+    it "does not tag the event" do
+      expect(subject.get("tags")).not_to include("beats_input_codec_plain_applied")
+    end
+  end
 end


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

This provides the "include_codec_tag" configuration option to allow
users to disable the application of the beats_input_codec_*_applied tag.

Closes #58
Closes #96