### PR TITLE
make the integration test work in latest filebeat master branch

### DIFF
--- a/spec/integration/filebeat_spec.rb
+++ b/spec/integration/filebeat_spec.rb
@@ -39,7 +39,8 @@ describe "Filebeat", :integration => true do
       "filebeat" => {
         "prospectors" => [{ "paths" => [log_file],  "input_type" => "log" }],
         "registry_file" => registry_file,
-        "scan_frequency" => "1s"
+        "scan_frequency" => "1s",
+        "idle_timeout" => "1s"
       },
       "output" => {
         "logstash" => { "hosts" => ["#{host}:#{port}"] },
@@ -84,7 +85,7 @@ describe "Filebeat", :integration => true do
           "output" => {
             "logstash" => {
               "hosts" => ["#{host}:#{port}"],
-              "tls" => { "certificate_authorities" => certificate_authorities }
+              "ssl" => { "certificate_authorities" => certificate_authorities }
             },
             "logging" => { "level" => "debug" }
           }})
@@ -134,10 +135,10 @@ describe "Filebeat", :integration => true do
             "output" => {
               "logstash" => {
                 "hosts" => ["#{host}:#{port}"],
-                "tls" => { 
+                "ssl" => {
                   "certificate_authorities" => certificate_authorities,
                   "certificate" => certificate_file,
-                  "certificate_key" => certificate_key_file
+                  "key" => certificate_key_file
                 }
               },
               "logging" => { "level" => "debug" }
@@ -215,10 +216,10 @@ describe "Filebeat", :integration => true do
                     "output" => {
                       "logstash" => {
                         "hosts" => ["#{host}:#{port}"],
-                        "tls" => { 
+                        "ssl" => {
                           "certificate_authorities" => certificate_authorities,
                           "certificate" => secondary_client_certificate_file,
-                          "certificate_key" => secondary_client_certificate_key_file
+                          "key" => secondary_client_certificate_key_file
                         }
                       },
                       "logging" => { "level" => "debug" }


### PR DESCRIPTION
Filebeat changed his options for SSLs and made all the integration test
use plain text.

The changes were the following

- tls -> ssl
- certificate_key => key