### PR TITLE
Fix an issue when specifying a passphrase that was raising a TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 3.1.5
+   - Fix an issue when using a passphrase was raising a TypeError #138
+   - Fix the filebeat integration suite to use the new `ssl` option instead of `tls`
    - Use correct log4j logger call to be compatible with 2.4
 
 ## 3.1.4

--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -169,7 +169,7 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
   def create_server
     server = org.logstash.beats.Server.new(@port)
     if @ssl
-      ssl_builder = org.logstash.netty.SslSimpleBuilder.new(ssl_certificate, ssl_key, ssl_key_passphrase)
+      ssl_builder = org.logstash.netty.SslSimpleBuilder.new(@ssl_certificate, @ssl_key, @ssl_key_passphrase.nil? ? nil : @ssl_key_passphrase.value)
         .setProtocols(convert_protocols)
         .setCipherSuites(normalized_ciphers)
 

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -3,9 +3,9 @@ OS_PLATFORM = RbConfig::CONFIG["host_os"]
 VENDOR_PATH = File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "vendor"))
 
 if OS_PLATFORM == "linux"
-  FILEBEAT_URL = "https://beats-nightlies.s3.amazonaws.com/filebeat/filebeat-5.0.0-alpha6-SNAPSHOT-linux-x86_64.tar.gz"
+  FILEBEAT_URL = "https://beats-nightlies.s3.amazonaws.com/filebeat/filebeat-6.0.0-alpha1-SNAPSHOT-linux-x86_64.tar.gz"
 elsif OS_PLATFORM == "darwin"
-  FILEBEAT_URL = "https://beats-nightlies.s3.amazonaws.com/filebeat/filebeat-5.0.0-alpha6-SNAPSHOT-darwin-x86_64.tar.gz"
+  FILEBEAT_URL = "https://beats-nightlies.s3.amazonaws.com/filebeat/filebeat-6.0.0-alpha1-SNAPSHOT-darwin-x86_64.tar.gz"
 end
 
 LSF_URL = "https://download.elastic.co/logstash-forwarder/binaries/logstash-forwarder_#{OS_PLATFORM}_amd64"

--- a/spec/integration/filebeat_spec.rb
+++ b/spec/integration/filebeat_spec.rb
@@ -39,7 +39,8 @@ describe "Filebeat", :integration => true do
       "filebeat" => {
         "prospectors" => [{ "paths" => [log_file],  "input_type" => "log" }],
         "registry_file" => registry_file,
-        "scan_frequency" => "1s"
+        "scan_frequency" => "1s",
+        "idle_timeout" => "1s"
       },
       "output" => {
         "logstash" => { "hosts" => ["#{host}:#{port}"] },
@@ -84,7 +85,7 @@ describe "Filebeat", :integration => true do
           "output" => {
             "logstash" => {
               "hosts" => ["#{host}:#{port}"],
-              "tls" => { "certificate_authorities" => certificate_authorities }
+              "ssl" => { "certificate_authorities" => certificate_authorities }
             },
             "logging" => { "level" => "debug" }
           }})
@@ -134,10 +135,10 @@ describe "Filebeat", :integration => true do
             "output" => {
               "logstash" => {
                 "hosts" => ["#{host}:#{port}"],
-                "tls" => { 
+                "ssl" => {
                   "certificate_authorities" => certificate_authorities,
                   "certificate" => certificate_file,
-                  "certificate_key" => certificate_key_file
+                  "key" => certificate_key_file
                 }
               },
               "logging" => { "level" => "debug" }
@@ -215,10 +216,10 @@ describe "Filebeat", :integration => true do
                     "output" => {
                       "logstash" => {
                         "hosts" => ["#{host}:#{port}"],
-                        "tls" => { 
+                        "ssl" => {
                           "certificate_authorities" => certificate_authorities,
                           "certificate" => secondary_client_certificate_file,
-                          "certificate_key" => secondary_client_certificate_key_file
+                          "key" => secondary_client_certificate_key_file
                         }
                       },
                       "logging" => { "level" => "debug" }


### PR DESCRIPTION
The passphrase uses the `Password` class to encapsulate the sensitive
information and make sure we dont write it to the log by accident, to
get the original value the plugin must call `#value` on the object.

The Java layer was expecting a string but was receive a Password
instance and was throwing an exception.

This commit make sure we use password and add an integration test for
it.

Fixes: #138 