### PR TITLE
rFix an issue when a rejectedError was raise by the executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.1.6
    - Fix an issue with the `READER_IDLE` that was closing a connection in a middle of working on a batch #141
-   - Fix an issue when the plugin did not accept a specific host to bind to.
+   - Fix an issue when the plugin did not accept a specific host to bind to. #146
+   - Fix an issue when forcing a logstash shutdown that could result in an `InterruptedException` #145
 
 ## 3.1.5
    - Fix an issue when using a passphrase was raising a TypeError #138

--- a/src/main/java/org/logstash/beats/Server.java
+++ b/src/main/java/org/logstash/beats/Server.java
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 public class Server {
     private final static Logger logger = Logger.getLogger(Server.class);
 
-    static final long SHUTDOWN_TIMEOUT_SECONDS = 10;
     private static final int DEFAULT_CLIENT_TIMEOUT_SECONDS = 15;
 
     private final int port;
@@ -71,10 +70,9 @@ public class Server {
             Channel channel = server.bind(host, port).sync().channel();
             channel.closeFuture().sync();
         } finally {
+            bossGroup.shutdownGracefully().sync();
+            workGroup.shutdownGracefully().sync();
             beatsInitializer.shutdownEventExecutor();
-
-            bossGroup.shutdownGracefully(0, SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            workGroup.shutdownGracefully(0, SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         }
 
         return this;
@@ -83,9 +81,9 @@ public class Server {
     public void stop() throws InterruptedException {
         logger.debug("Server shutting down");
 
-        Future<?> bossWait = bossGroup.shutdownGracefully(0, SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        Future<?> workWait = workGroup.shutdownGracefully(0, SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        
+        bossGroup.shutdownGracefully().sync();
+        workGroup.shutdownGracefully().sync();
+
         logger.debug("Server stopped");
     }
 
@@ -148,11 +146,16 @@ public class Server {
 
         @Override
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            logger.warn("Channel initializer");
             this.message.onChannelInitializeException(ctx, cause);
         }
 
         public void shutdownEventExecutor() {
-            idleExecutorGroup.shutdownGracefully(0, SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            try {
+                idleExecutorGroup.shutdownGracefully().sync();
+            } catch (InterruptedException e) {
+                // we are shutting down we don't care about any errors here.
+            }
         }
     }
 }


### PR DESCRIPTION
The problem was the order of the shutdown was not correctly defined and
was async, this PR change the flow to wait for the workgroup and
bossgroup executor to be closed before terminating the idlestate
executor.

Also, I've changed the parameters of shutdownGracefully to use the
default method of netty which users saner default values for the quiet
time and make the code close more reliably when shutting down
Logstash.