### PR TITLE
Validate the presence of certificate authorities

### DIFF
--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -153,6 +153,10 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
       raise LogStash::ConfigurationError, "Certificate or Certificate Key not configured"
     end
 
+    if @ssl && require_certificate_authorities? && !client_authentification?
+      raise LogStash::ConfigurationError, "Using `verify_mode` set to PEER or FORCE_PEER, requires the configuration of `certificate_authorities`"
+    end
+
     @logger.info("Beats inputs: Starting input listener", :address => "#{@host}:#{@port}")
 
     # wrap the configured codec to support identity stream
@@ -218,6 +222,10 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
 
   def client_authentification?
     @ssl_certificate_authorities && @ssl_certificate_authorities.size > 0
+  end
+
+  def require_certificate_authorities?
+    @ssl_verify_mode == "force_peer" || @ssl_verify_mode == "peer"
   end
 
   def normalized_ciphers

--- a/spec/inputs/beats_spec.rb
+++ b/spec/inputs/beats_spec.rb
@@ -70,6 +70,38 @@ describe LogStash::Inputs::Beats do
           expect { plugin.register }.to raise_error(LogStash::ConfigurationError)
         end
       end
+
+      context "verify_mode" do
+        context "verify_mode configured to PEER" do
+          let(:config)   { { "port" => 0, "ssl" => true, "ssl_verify_mode" => "peer", "ssl_certificate" => certificate.ssl_cert, "ssl_key" => certificate.ssl_key, "type" => "example", "tags" => "Beats"} }
+
+          it "raise a ConfigurationError when certificate_authorities is not set" do
+            plugin = LogStash::Inputs::Beats.new(config)
+            expect {plugin.register}.to raise_error(LogStash::ConfigurationError, "Using `verify_mode` set to PEER or FORCE_PEER, requires the configuration of `certificate_authorities`")
+          end
+
+          it "doesn't raise a configuration error when certificate_authorities is set" do
+            config.merge!({ "ssl_certificate_authorities" => [certificate.ssl_cert]})
+            plugin = LogStash::Inputs::Beats.new(config)
+            expect {plugin.register}.not_to raise_error
+          end
+        end
+
+        context "verify_mode configured to FORCE_PEER" do
+          let(:config)   { { "port" => 0, "ssl" => true, "ssl_verify_mode" => "force_peer", "ssl_certificate" => certificate.ssl_cert, "ssl_key" => certificate.ssl_key, "type" => "example", "tags" => "Beats"} }
+
+          it "raise a ConfigurationError when certificate_authorities is not set" do
+            plugin = LogStash::Inputs::Beats.new(config)
+            expect {plugin.register}.to raise_error(LogStash::ConfigurationError, "Using `verify_mode` set to PEER or FORCE_PEER, requires the configuration of `certificate_authorities`")
+          end
+
+          it "doesn't raise a configuration error when certificate_authorities is set" do
+            config.merge!({ "ssl_certificate_authorities" => [certificate.ssl_cert]})
+            plugin = LogStash::Inputs::Beats.new(config)
+            expect {plugin.register}.not_to raise_error
+          end
+        end
+      end
     end
 
     context "with ssl disabled" do


### PR DESCRIPTION
When we set the `ssl_verify_mode` to `peer` or `force_peer` we should
make the `certificate_authorities` mandatory, when the option is not set
we will now throw a configuration error.

Fixes: #151
