### PR TITLE
Mark the congestion threshold as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.1.10
   - Correctly send the client_inactivity_timeout to the Server classe #163
+  - Mark congestion_threshold as deprecated, the java implementation now use a keep alive mechanism
 
 ## 3.1.9
   - Docs: Removed statement about intermediate CAs not being supported

--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -118,7 +118,7 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
 
   # The number of seconds before we raise a timeout. 
   # This option is useful to control how much time to wait if something is blocking the pipeline.
-  config :congestion_threshold, :validate => :number, :default => 5, :deprecated => "This option is now deprecated, the plugin now use a keep alive mechanism to inform Filebeat"
+  config :congestion_threshold, :validate => :number, :default => 5, :deprecated => "This option is now deprecated since congestion control is done automatically"
 
   # This is the default field to which the specified codec will be applied.
   config :target_field_for_codec, :validate => :string, :default => "message", :deprecated => "This option is now deprecated, the plugin is now compatible with Filebeat and Logstash-Forwarder"

--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -118,7 +118,7 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
 
   # The number of seconds before we raise a timeout. 
   # This option is useful to control how much time to wait if something is blocking the pipeline.
-  config :congestion_threshold, :validate => :number, :default => 5
+  config :congestion_threshold, :validate => :number, :default => 5, :deprecated => "This option is now deprecated, the plugin now use a keep alive mechanism to inform Filebeat"
 
   # This is the default field to which the specified codec will be applied.
   config :target_field_for_codec, :validate => :string, :default => "message", :deprecated => "This option is now deprecated, the plugin is now compatible with Filebeat and Logstash-Forwarder"


### PR DESCRIPTION
This option is not used anymore and should have been marked as
deprecated, the input now uses at keep alive to FB (sending ack 0) to
inform the client that some back pressure is happening.