### PR TITLE
Bootstrap check to see if the configured temporary directory is mounted with noexec

### DIFF
--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -5,6 +5,7 @@ require "logstash/timestamp"
 require "logstash/codecs/identity_map_codec"
 require "logstash/codecs/multiline"
 require "logstash/util"
+require "logstash/errors"
 require "logstash-input-beats_jars"
 
 # This input plugin enables Logstash to receive events from the
@@ -60,6 +61,7 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
   require "logstash/inputs/beats/decoded_event_transform"
   require "logstash/inputs/beats/raw_event_transform"
   require "logstash/inputs/beats/message_listener"
+  require "logstash/inputs/beats/stats_helper"
   require "logstash/inputs/beats/tls"
 
   config_name "beats"
@@ -175,6 +177,7 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
   def create_server
     server = org.logstash.beats.Server.new(@host, @port, @client_inactivity_timeout)
     if @ssl
+      check_no_exec_mount!
 
       begin
       ssl_builder = org.logstash.netty.SslSimpleBuilder.new(@ssl_certificate, @ssl_key, @ssl_key_passphrase.nil? ? nil : @ssl_key_passphrase.value)
@@ -235,5 +238,21 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
 
   def convert_protocols
     TLS.get_supported(@tls_min_version..@tls_max_version).map(&:name)
+  end
+
+  def check_no_exec_mount!
+    if !LogStash::Environment.windows?
+      path = StatsHelper.netty_temporary_dir
+      if StatsHelper.noexec?(path)
+        message =<<-EOS
+The beats input is using the temporary directory `#{path}` for extracting his native SSL libraries, the mount point has the `noexec` option on,
+this prevent the netty input to use the native library and make some ciphers not available.
+
+You can change the temporary directory using the $LOGSTASH_HOME/config/jvm.options and add this line `-Dio.netty.native.workdir=/var/logstash/tmp`,
+make sure that the logstash process can write and read from that directory.
+        EOS
+        raise LogStash::ConfigurationError, message
+      end
+    end
   end
 end

--- a/lib/logstash/inputs/beats/stats_helper.rb
+++ b/lib/logstash/inputs/beats/stats_helper.rb
@@ -1,0 +1,49 @@
+# encoding: utf-8
+require "sys/filesystem"
+require "fileutils"
+
+module LogStash module Inputs class Beats
+  class StatsHelper
+    # bitmask
+    NO_EXEC_FLAG = 8
+
+    # We want to be able to display a better error message, but I cannot call any public method
+    # on netty classes to get the possible temporary directory so I have to port that logic here.
+    #
+    # But we only care about linux/unix
+    #
+    # https://netty.io/4.0/xref/io/netty/util/internal/NativeLibraryLoader.html
+    #
+    def self.netty_temporary_dir
+      st = java.lang.System
+      dir = st.getProperties["io.netty.native.workdir"] || st.getProperties["io.netty.tmpdir"] || st.getProperties["java.io.tmpdir"] || "/tmp"
+
+      # Force creation, to make sure we can test with noexec
+      FileUtils.mkdir_p(dir)
+      dir
+    end
+
+    def self.noexec?(path)
+      path = ::File.expand_path(path)
+
+      parts = path.split(::File::SEPARATOR)
+      number_of_iteration = parts.size
+
+      results = {}
+
+      number_of_iteration.times.collect do
+        new_path = ::File.join(*parts)
+
+        # we are interested all all the hierachy
+        # but some directories could no exist yet?
+        if Dir.exist?(new_path)
+          stats = Sys::Filesystem.stat(new_path)
+          results[new_path] = (stats.flags & NO_EXEC_FLAG) != 0
+        end
+        parts.pop
+      end
+
+      results.values.any?
+    end
+  end
+end end end

--- a/logstash-input-beats.gemspec
+++ b/logstash-input-beats.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "thread_safe", "~> 0.3.5"
   s.add_runtime_dependency "logstash-codec-multiline", ">= 2.0.5"
   s.add_runtime_dependency 'jar-dependencies', '~> 0.3.4'
+  s.add_runtime_dependency "sys-filesystem"
 
   s.add_development_dependency "flores", "~>0.0.6"
   s.add_development_dependency "rspec"

--- a/spec/inputs/beats/codec_callback_listener_spec.rb
+++ b/spec/inputs/beats/codec_callback_listener_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
+require "spec_helper"
 require "logstash/inputs/beats"
 require "logstash/event"
-require "spec_helper"
 require "thread"
 
 describe LogStash::Inputs::Beats::CodecCallbackListener do

--- a/spec/inputs/beats/decoded_event_transform_spec.rb
+++ b/spec/inputs/beats/decoded_event_transform_spec.rb
@@ -1,9 +1,9 @@
 # encoding: utf-8
+require "spec_helper"
 require "logstash/event"
 require "logstash/timestamp"
 require "logstash/inputs/beats"
 require_relative "../../support/shared_examples"
-require "spec_helper"
 
 describe LogStash::Inputs::Beats::DecodedEventTransform do
   let(:config) do

--- a/spec/inputs/beats/event_transform_common_spec.rb
+++ b/spec/inputs/beats/event_transform_common_spec.rb
@@ -1,8 +1,8 @@
 # encoding: utf-8
+require "spec_helper"
 require "logstash/event"
 require "logstash/inputs/beats"
 require_relative "../../support/shared_examples"
-require "spec_helper"
 
 describe LogStash::Inputs::Beats::EventTransformCommon do
   subject { described_class.new(input).transform(event) }

--- a/spec/inputs/beats/message_listener_spec.rb
+++ b/spec/inputs/beats/message_listener_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require "spec_helper"
 require "logstash/inputs/beats"
 require "logstash/event"
 require "logstash/inputs/beats/message_listener"

--- a/spec/inputs/beats/raw_event_transform_spec.rb
+++ b/spec/inputs/beats/raw_event_transform_spec.rb
@@ -1,8 +1,8 @@
 # encoding: utf-8
+require "spec_helper"
 require "logstash/event"
 require "logstash/inputs/beats"
 require_relative "../../support/shared_examples"
-require "spec_helper"
 
 describe LogStash::Inputs::Beats::RawEventTransform do
   let(:config) do

--- a/spec/inputs/beats/tls_spec.rb
+++ b/spec/inputs/beats/tls_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require "spec_helper"
 require "logstash/inputs/beats/tls"
 
 describe LogStash::Inputs::Beats::TLS do

--- a/spec/integration/filebeat_spec.rb
+++ b/spec/integration/filebeat_spec.rb
@@ -1,10 +1,10 @@
 # encoding: utf-8
+require "spec_helper"
 require "logstash/inputs/beats"
 require "stud/temporary"
 require "flores/pki"
 require "fileutils"
 require "thread"
-require "spec_helper"
 require "yaml"
 require "fileutils"
 require "flores/pki"

--- a/spec/integration/logstash_forwarder_spec.rb
+++ b/spec/integration/logstash_forwarder_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require "spec_helper"
 require "logstash/inputs/beats"
 require "logstash/json"
 require "fileutils"


### PR DESCRIPTION
When you start logstash and the temporary directory is mounted with
`noexec` and you are using SSL this will make the netty library fails to
load the native library. This PR add a bootstrap check and a betters
message than missing a ciphers.

Fixes: #174


Notes for reviewer: Writing test for this isn't an easy task, I've tested it manually by creating a ramdisk with the `noexec` option and changing the config/logstash.yml directory to point to that.