### PR TITLE
Simple fix to make the input not set the CAs when the verifymode is s…

### DIFF
--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -190,7 +190,9 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
         if @ssl_verify_mode.upcase == "FORCE_PEER"
             ssl_builder.setVerifyMode(org.logstash.netty.SslSimpleBuilder::SslClientVerifyMode::FORCE_PEER)
         end
-        ssl_builder.setCertificateAuthorities(@ssl_certificate_authorities)
+        if @ssl_verify_mode.upcase != "NONE"
+            ssl_builder.setCertificateAuthorities(@ssl_certificate_authorities)
+        end
       end
 
       server.enableSSL(ssl_builder)


### PR DESCRIPTION
For a bit of context, please see the discussion (or lack thereof) at https://discuss.elastic.co/t/beats-input-not-behaving-as-documented/73360.

I attempted to run (and possibly write new) tests for this, but got stuck with some errors running 'bundle exec rspec'. Any help in this area would be much appreciated. 

Cheers, 
Nick