### PR TITLE
Properly close multiple idle connections

### DIFF
--- a/spec/inputs/beats/codec_callback_listener_spec.rb
+++ b/spec/inputs/beats/codec_callback_listener_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
+require_relative "../../spec_helper"
 require "logstash/inputs/beats"
 require "logstash/event"
-require "spec_helper"
 require "thread"
 
 describe LogStash::Inputs::Beats::CodecCallbackListener do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
 # encoding: utf-8
+require "logstash/devutils/rspec/spec_helper"
 require "rspec"
 require "rspec/mocks"
 require "rspec/wait"
-require "logstash/devutils/rspec/spec_helper"
 require "logstash/codecs/plain"
 require_relative "support/logstash_test"
 require_relative "support/helpers"

--- a/src/test/java/org/logstash/beats/ServerTest.java
+++ b/src/test/java/org/logstash/beats/ServerTest.java
@@ -1,23 +1,31 @@
 package org.logstash.beats;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.*;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.net.ConnectException;
 import java.util.Collections;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.lang.Thread.sleep;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.number.IsCloseTo.closeTo;
-import static org.junit.Assert.assertTrue;
 
 
 public class ServerTest {
@@ -34,9 +42,43 @@ public class ServerTest {
     @Test
     public void testServerShouldTerminateConnectionIdleForTooLong() throws InterruptedException {
         int inactivityTime = 3; // in seconds
+        int concurrentConnections = 10;
+
+        final Random random = new Random();
+
+        final CountDownLatch latch = new CountDownLatch(concurrentConnections);
 
         final Server server = new Server(host, randomPort, inactivityTime);
+        final AtomicBoolean otherCause = new AtomicBoolean(false);
+        server.setMessageListener(new MessageListener() {
+            public void onNewConnection(ChannelHandlerContext ctx) {
+                // Make sure connection is closed on exception too.
+                if (random.nextInt(10) < 1) {
+                    throw new RuntimeException("Dummy");
+                }
+            }
 
+            @Override
+            public void onConnectionClose(ChannelHandlerContext ctx) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onNewMessage(ChannelHandlerContext ctx, Message message) {
+                // Make sure connection is closed on exception too.
+                if (random.nextInt(10) < 1) {
+                    throw new RuntimeException("Dummy");
+                }
+            }
+
+            @Override
+            public void onException(ChannelHandlerContext ctx, Throwable cause) {
+                // Make sure only intended exception is thrown
+                if (!"Dummy".equals(cause.getMessage())) {
+                    otherCause.set(true);
+                }
+            }
+        });
 
         Runnable serverTask = new Runnable() {
             @Override
@@ -52,18 +94,20 @@ public class ServerTest {
         thread.start();
         sleep(1000); // give some time to travis..
 
-        EventLoopGroup group = new NioEventLoopGroup();
-
         try {
             Long started = System.currentTimeMillis() / 1000L;
 
-            connectClient().sync().channel().closeFuture().sync();
+
+            for (int i = 0; i < concurrentConnections; i++) {
+                connectClient();
+            }
+            latch.await(10, TimeUnit.SECONDS);
 
             Long ended = System.currentTimeMillis() / 1000L;
 
             double diff = ended - started;
             assertThat(diff, is(closeTo(inactivityTime, 0.1)));
-
+            assertThat(otherCause.get(), is(false));
         } finally {
             server.stop();
         }


### PR DESCRIPTION
Fixes an issue where it doesn't close connections even after client_inactivity_timeout
has passed when there are multiple connections.
