### PR TITLE
update openssl pkcs8 link

### DIFF
--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -81,7 +81,7 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
   config :ssl_certificate, :validate => :path
 
   # SSL key to use.
-  # NOTE: This key need to be in the PKCS8 format, you can convert it with https://www.openssl.org/docs/manmaster/apps/pkcs8.html[OpenSSL]
+  # NOTE: This key need to be in the PKCS8 format, you can convert it with https://www.openssl.org/docs/man1.1.0/apps/pkcs8.html[OpenSSL]
   # for more information.
   config :ssl_key, :validate => :path
 


### PR DESCRIPTION
The current link (https://www.openssl.org/docs/manmaster/apps/pkcs8.html) results in a 404. Not sure why it is missing on the openssl master branch. Updated to point to the latest openssl release, which works fine (https://www.openssl.org/docs/man1.1.0/apps/pkcs8.html)

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
