### PR TITLE
3.x only: Deprecate multiline codec with the Beats input plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.1.16
  - Docs: Add note indicating that the multiline codec should not be used with the Beats input plugin
+ - Deprecate warning for multiline codec with the Beats input plugin
 
 ## 3.1.15
  - DEBUG: Add information about the remote when an exception is catched #192

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 logstash_path = "../../logstash"
 
-if Dir.exist?(logstash_path) && ENV["LOGSTASH_SOURCE"] == 1
+if Dir.exist?(logstash_path) && ENV["LOGSTASH_SOURCE"] == "1"
   gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
   gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
 end

--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -147,6 +147,10 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
       raise LogStash::ConfigurationError, "Using `verify_mode` set to PEER or FORCE_PEER, requires the configuration of `certificate_authorities`"
     end
 
+    if @codec.kind_of? LogStash::Codecs::Multiline
+      @logger.warn("WARNING! - Multiline codec with beats input has been deprecated. Support for this configuration will be removed in a future version. Please refer to the beats documentation for how to best manage multiline data. See https://www.elastic.co/guide/en/beats/filebeat/current/multiline-examples.html")
+    end
+
     @logger.info("Beats inputs: Starting input listener", :address => "#{@host}:#{@port}")
 
     # wrap the configured codec to support identity stream


### PR DESCRIPTION
Fixes: #208

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
