### PR TITLE
Return proper exit code when ./gradlew vendor fails

### DIFF
--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -3,7 +3,7 @@ require "jars/installer"
 require "fileutils"
 
 task :vendor do
-  system("./gradlew vendor")
+  exit(1) unless system './gradlew vendor'
   version = File.read("VERSION").strip
 end
 


### PR DESCRIPTION
Fixes #210

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
