### PR TITLE
Include Remote IP address in the Event medata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.3
+ - Include remote ip_address in metadata.
+
 ## 4.0.2
  - Relax version of concurrent-ruby to `~> 1.0`
 

--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -39,8 +39,7 @@ require_relative "beats/patch"
 # IMPORTANT: If you are shipping events that span multiple lines, you need to
 # use the configuration options available in Filebeat to handle multiline events
 # before sending the event data to Logstash. You cannot use the
-# <<plugins-codecs-multiline>> codec to handle multiline events. Doing so may
-# result in the mixing of streams and corrupted event data. 
+# <<plugins-codecs-multiline>> codec to handle multiline events.
 #
 class LogStash::Inputs::Beats < LogStash::Inputs::Base
   require "logstash/inputs/beats/codec_callback_listener"

--- a/lib/logstash/inputs/beats/message_listener.rb
+++ b/lib/logstash/inputs/beats/message_listener.rb
@@ -29,6 +29,12 @@ module LogStash module Inputs class Beats
     def onNewMessage(ctx, message)
       hash = message.getData()
 
+      begin
+        hash.get("@metadata").put("ip_address", ctx.channel().remoteAddress().getAddress().getHostAddress())
+      rescue #should never happen, but don't allow an error here to stop beats input
+        input.logger.warn("Could not retrieve remote IP address for beats input.")
+      end
+
       target_field = extract_target_field(hash)
 
       if target_field.nil?


### PR DESCRIPTION
Adds ip_address to the @metadata field. The ip is the remote host address as seen by Netty.

Fixes #180

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
