### PR TITLE
Fix exception not printed in debug log

### DIFF
--- a/lib/logstash/inputs/beats/message_listener.rb
+++ b/lib/logstash/inputs/beats/message_listener.rb
@@ -64,9 +64,9 @@ module LogStash module Inputs class Beats
       # This is mostly due to a bad certificate or keys, running Logstash in debug mode will show more information
       if cause.is_a?(Java::JavaLang::IllegalArgumentException)
         if input.logger.debug?
-          input.logger.error("Looks like you either have an invalid key or your private key was not in PKCS8 format.")
+          input.logger.error("Looks like you either have a bad certificate, an invalid key or your private key was not in PKCS8 format.", :exception => cause)
         else
-          input.logger.error("Looks like you either have an invalid key or your private key was not in PKCS8 format.", :exception => cause)
+          input.logger.error("Looks like you either have a bad certificate, an invalid key or your private key was not in PKCS8 format.")
         end
       else
         input.logger.warn("Error when creating a connection", :exception => cause.to_s)


### PR DESCRIPTION
The condition for printing the exception in debug mode was most probably inverted, causing the exception to be printed in normal mode instead, which caused quite a headache. Also, the message is unclear, because that exception can happen in case of certificate issues too, so I added some clarification.