### PR TITLE
Change the idle strategy

### DIFF
--- a/src/main/java/org/logstash/beats/BeatsHandler.java
+++ b/src/main/java/org/logstash/beats/BeatsHandler.java
@@ -75,7 +75,7 @@ public class BeatsHandler extends SimpleChannelInboundHandler<Batch> {
 
             if(e.state() == IdleState.WRITER_IDLE) {
                 sendKeepAlive();
-            } else if(e.state() == IdleState.READER_IDLE) {
+            } else if(e.state() == IdleState.ALL_IDLE) {
                 clientTimeout();
             }
         }

--- a/src/main/java/org/logstash/beats/Server.java
+++ b/src/main/java/org/logstash/beats/Server.java
@@ -104,7 +104,6 @@ public class Server {
 
         private final int DEFAULT_IDLESTATEHANDLER_THREAD = 4;
         private final int IDLESTATE_WRITER_IDLE_TIME_SECONDS = 5;
-        private final int IDLESTATE_ALL_IDLE_TIME_SECONDS = 0;
 
         private final EventExecutorGroup idleExecutorGroup;
         private final IMessageListener message;
@@ -133,7 +132,7 @@ public class Server {
 
             // We have set a specific executor for the idle check, because the `beatsHandler` can be
             // blocked on the queue, this the idleStateHandler manage the `KeepAlive` signal.
-            pipeline.addLast(idleExecutorGroup, KEEP_ALIVE_HANDLER, new IdleStateHandler(clientInactivityTimeoutSeconds, IDLESTATE_WRITER_IDLE_TIME_SECONDS , IDLESTATE_ALL_IDLE_TIME_SECONDS));
+            pipeline.addLast(idleExecutorGroup, KEEP_ALIVE_HANDLER, new IdleStateHandler(0, IDLESTATE_WRITER_IDLE_TIME_SECONDS , clientInactivityTimeoutSeconds));
 
             pipeline.addLast(BEATS_PARSER, new BeatsParser());
             pipeline.addLast(BEATS_ACKER, new AckEncoder());


### PR DESCRIPTION
In the previous version of the beats input we were using the `IdleState.READER_IDLE`, which
is triggered when `no read was performed for the specified period of time`
This mean that we could trigger a timeout just after reading a batch
that take a long time processing.

We actually want to timeout when we didn't write (acks or keep alive) or read new events for X amount of time, so we need to use the `IdleState.ALL_IDLE`

This is important, because killing connection will make libbeat start
with a slow start strategy.

linked to #260 
