### PR TITLE
MINOR: Gitignore Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ build/
 *.iws
 log4j2.xml_bk
 Gemfile.lock
+lib/logstash-input-beats_jars.rb

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ build/
 *.ipr
 *.iws
 log4j2.xml_bk
+Gemfile.lock


### PR DESCRIPTION
We're not committing the `Gemfile.lock` and `lib/logstash-input-beats_jars.rb` to any branch or tag as far as I can see =>`gitignore` them to not have to delete them before every commit.