### PR TITLE
Fix thread leak when pipeline is reloaded

### DIFF
--- a/src/main/java/org/logstash/beats/KeepAliveHandler.java
+++ b/src/main/java/org/logstash/beats/KeepAliveHandler.java
@@ -36,13 +36,16 @@ public class KeepAliveHandler extends ChannelDuplexHandler {
                 logger.debug("reader and writer are idle, closing remote connection");
                 ctx.flush();
                 ChannelFuture f = ctx.close();
-                f.addListener((future) ->{
-                   if (future.isSuccess()){
-                       logger.warn("success");
-                   } else {
-                        logger.warn("could not close the ctx");
-                   }
-                });
+
+                if (logger.isTraceEnabled()) {
+                    f.addListener((future) -> {
+                        if (future.isSuccess()) {
+                            logger.trace("closed ctx successfully");
+                        } else {
+                            logger.trace("could not close ctx");
+                        }
+                    });
+                }
             }
         }
     }

--- a/src/main/java/org/logstash/beats/Server.java
+++ b/src/main/java/org/logstash/beats/Server.java
@@ -30,6 +30,7 @@ public class Server {
     private final int beatsHeandlerThreadCount;
     private IMessageListener messageListener = new MessageListener();
     private SslSimpleBuilder sslBuilder;
+    private BeatsInitializer beatsInitializer;
 
     private final int clientInactivityTimeoutSeconds;
 
@@ -50,8 +51,6 @@ public class Server {
     }
 
     public Server listen() throws InterruptedException {
-        BeatsInitializer beatsInitializer = null;
-
         try {
             logger.info("Starting server on port: " +  this.port);
 
@@ -66,8 +65,7 @@ public class Server {
             Channel channel = server.bind(host, port).sync().channel();
             channel.closeFuture().sync();
         } finally {
-            workGroup.shutdownGracefully().sync();
-            beatsInitializer.shutdownEventExecutor();
+            shutdown();
         }
 
         return this;
@@ -75,8 +73,17 @@ public class Server {
 
     public void stop() throws InterruptedException {
         logger.debug("Server shutting down");
-        workGroup.shutdownGracefully().sync();
+        shutdown();
         logger.debug("Server stopped");
+    }
+
+    private void shutdown(){
+        try {
+            workGroup.shutdownGracefully().sync();
+            beatsInitializer.shutdownEventExecutor();
+        } catch (InterruptedException e){
+            throw new IllegalStateException(e);
+        }
     }
 
     public void setMessageListener(IMessageListener listener) {
@@ -131,15 +138,16 @@ public class Server {
 
         @Override
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-            logger.warn("Channel initializer");
+            logger.warn("Exception caught in channel initializer", cause);
             this.message.onChannelInitializeException(ctx, cause);
         }
 
         public void shutdownEventExecutor() {
             try {
                 idleExecutorGroup.shutdownGracefully().sync();
+                beatsHandlerExecutorGroup.shutdownGracefully().sync();
             } catch (InterruptedException e) {
-                // we are shutting down we don't care about any errors here.
+                throw new IllegalStateException(e);
             }
         }
     }


### PR DESCRIPTION
stop() method was not closing down the beatsHandler event executor group.
Adds a standard shutdown() method to that can be used if the listen() method exits, or the stop method is called.
Also fixes up some overly noisy logging in the KeepAliveHandler