### PR TITLE
Backport: Rework the NioEventLoop handling in the beats input

### DIFF
--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -121,6 +121,9 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
   # Close Idle clients after X seconds of inactivity.
   config :client_inactivity_timeout, :validate => :number, :default => 60
 
+  # Beats handler executor thread
+  config :executor_threads, :validate => :number, :default => LogStash::Config::CpuCoreStrategy.maximum * 4
+
   def register
     # For Logstash 2.4 we need to make sure that the logger is correctly set for the
     # java classes before actually loading them.
@@ -166,7 +169,7 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
   end # def register
 
   def create_server
-    server = org.logstash.beats.Server.new(@host, @port, @client_inactivity_timeout)
+    server = org.logstash.beats.Server.new(@host, @port, @client_inactivity_timeout, @executor_threads)
     if @ssl
 
       begin

--- a/spec/inputs/beats_spec.rb
+++ b/spec/inputs/beats_spec.rb
@@ -16,15 +16,16 @@ describe LogStash::Inputs::Beats do
 
   context "#register" do
     context "host related configuration" do
-      let(:config) { super.merge!({ "host" => host, "port" => port, "client_inactivity_timeout" => client_inactivity_timeout }) }
+      let(:config) { super.merge!({ "host" => host, "port" => port, "client_inactivity_timeout" => client_inactivity_timeout, "executor_threads" => threads }) }
       let(:host) { "192.168.1.20" }
       let(:port) { 9000 }
       let(:client_inactivity_timeout) { 400 }
+      let(:threads) { 10 }
 
       subject(:plugin) { LogStash::Inputs::Beats.new(config) }
 
       it "sends the required options to the server" do
-        expect(org.logstash.beats.Server).to receive(:new).with(host, port, client_inactivity_timeout)
+        expect(org.logstash.beats.Server).to receive(:new).with(host, port, client_inactivity_timeout, threads)
         subject.register
       end
     end

--- a/src/main/java/org/logstash/beats/BeatsHandler.java
+++ b/src/main/java/org/logstash/beats/BeatsHandler.java
@@ -1,20 +1,17 @@
 package org.logstash.beats;
 
-import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.handler.timeout.IdleState;
-import io.netty.handler.timeout.IdleStateEvent;
+import io.netty.util.AttributeKey;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.net.InetSocketAddress;
-import java.net.SocketAddress;
-import java.util.concurrent.atomic.AtomicBoolean;
+import javax.net.ssl.SSLHandshakeException;
 
 public class BeatsHandler extends SimpleChannelInboundHandler<Batch> {
     private final static Logger logger = LogManager.getLogger(BeatsHandler.class);
-    private final AtomicBoolean processing = new AtomicBoolean(false);
+    public static AttributeKey<Boolean> PROCESSING_BATCH = AttributeKey.valueOf("processing-batch");
     private final IMessageListener messageListener;
     private ChannelHandlerContext context;
 
@@ -27,19 +24,22 @@ public class BeatsHandler extends SimpleChannelInboundHandler<Batch> {
     public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
         context = ctx;
         messageListener.onNewConnection(ctx);
+        // Give some breathing room on new clients to receive the keep alive.
+        ctx.channel().attr(PROCESSING_BATCH).set(false);
     }
 
     @Override
     public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+        ctx.channel().attr(PROCESSING_BATCH).set(false);
         messageListener.onConnectionClose(ctx);
     }
+
 
     @Override
     public void channelRead0(ChannelHandlerContext ctx, Batch batch) throws Exception {
         logger.debug("Received a new payload");
 
-        processing.compareAndSet(false, true);
-
+        ctx.channel().attr(PROCESSING_BATCH).set(true);
         for(Message message : batch.getMessages()) {
             if(logger.isDebugEnabled()) {
                 logger.debug("Sending a new message for the listener, sequence: " + message.getSequence());
@@ -51,33 +51,32 @@ public class BeatsHandler extends SimpleChannelInboundHandler<Batch> {
             }
         }
         ctx.flush();
-        processing.compareAndSet(true, false);
-
+        ctx.channel().attr(PROCESSING_BATCH).set(false);
     }
 
+    /*
+     * Do not propagate the SSL handshake exception down to the ruby layer handle it locally instead and close the connection
+     * if the channel is still active. Calling `onException` will flush the content of the codec's buffer, this call
+     * may block the thread in the event loop until completion, this should only affect LS 5 because it still supports
+     * the multiline codec, v6 drop support for buffering codec in the beats input.
+     *
+     * For v5, I cannot drop the content of the buffer because this will create data loss because multiline content can
+     * overlap Filebeat transmission; we were recommending multiline at the source in v5 and in v6 we enforce it.
+     */
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        ctx.close();
+
+        if (!(cause instanceof SSLHandshakeException)) {
+            messageListener.onException(ctx, cause);
+        }
+
         InetSocketAddress remoteAddress = (InetSocketAddress) ctx.channel().remoteAddress();
 
         if (remoteAddress != null) {
             logger.info("Exception: " + cause.getMessage() + ", from: " + remoteAddress.toString());
         } else {
             logger.info("Exception: " + cause.getMessage());
-        }
-        messageListener.onException(ctx, cause);
-        ctx.close();
-    }
-
-    @Override
-    public void userEventTriggered(ChannelHandlerContext ctx, Object event) {
-        if(event instanceof IdleStateEvent) {
-            IdleStateEvent e = (IdleStateEvent) event;
-
-            if(e.state() == IdleState.WRITER_IDLE) {
-                sendKeepAlive();
-            } else if(e.state() == IdleState.READER_IDLE) {
-                clientTimeout();
-            }
         }
     }
 
@@ -91,20 +90,5 @@ public class BeatsHandler extends SimpleChannelInboundHandler<Batch> {
 
     private void writeAck(ChannelHandlerContext ctx, byte protocol, int sequence) {
         ctx.write(new Ack(protocol, sequence));
-    }
-
-    private void clientTimeout() {
-        if(!processing.get()) {
-            logger.debug("Client Timeout");
-            this.context.close();
-        }
-    }
-
-    private void sendKeepAlive() {
-        // If we are actually blocked on processing
-        // we can send a keep alive.
-        if(processing.get()) {
-            writeAck(context, Protocol.VERSION_2, 0);
-        }
     }
 }

--- a/src/main/java/org/logstash/beats/KeepAliveHandler.java
+++ b/src/main/java/org/logstash/beats/KeepAliveHandler.java
@@ -6,6 +6,8 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -23,11 +25,14 @@ public class KeepAliveHandler extends ChannelDuplexHandler {
                     ChannelFuture f = ctx.writeAndFlush(new Ack(Protocol.VERSION_2, 0));
                     if (logger.isTraceEnabled()) {
                         logger.trace("sending keep alive ack to libbeat");
-                        f.addListener((ChannelFutureListener) future -> {
-                            if (future.isSuccess()) {
-                                logger.trace("acking was successful");
-                            } else {
-                                logger.trace("acking failed");
+                        f.addListener(new ChannelFutureListener() {
+                            @Override
+                            public void operationComplete(final ChannelFuture future) throws Exception {
+                                if (future.isSuccess()) {
+                                    logger.trace("acking was successful");
+                                } else {
+                                    logger.trace("acking failed");
+                                }
                             }
                         });
                     }
@@ -36,13 +41,20 @@ public class KeepAliveHandler extends ChannelDuplexHandler {
                 logger.debug("reader and writer are idle, closing remote connection");
                 ctx.flush();
                 ChannelFuture f = ctx.close();
-                f.addListener((future) ->{
-                   if (future.isSuccess()){
-                       logger.warn("success");
-                   } else {
-                        logger.warn("could not close the ctx");
-                   }
-                });
+                if (logger.isTraceEnabled()) {
+                    logger.trace("sending keep alive ack to libbeat");
+
+                    f.addListener(new GenericFutureListener<Future<? super Void>>() {
+                        @Override
+                        public void operationComplete(final Future<? super Void> future) throws Exception {
+                            if (future.isSuccess()) {
+                                logger.trace("closed ctx successfully");
+                            } else {
+                                logger.trace("could not close ctx");
+                            }
+                        }
+                    });
+                }
             }
         }
     }

--- a/src/main/java/org/logstash/beats/KeepAliveHandler.java
+++ b/src/main/java/org/logstash/beats/KeepAliveHandler.java
@@ -1,0 +1,53 @@
+package org.logstash.beats;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.timeout.IdleState;
+import io.netty.handler.timeout.IdleStateEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class KeepAliveHandler extends ChannelDuplexHandler {
+    private final static Logger logger = LogManager.getLogger(KeepAliveHandler.class);
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        IdleStateEvent e = null;
+
+        if (evt instanceof IdleStateEvent) {
+            e = (IdleStateEvent) evt;
+            if (e.state() == IdleState.WRITER_IDLE) {
+                if (isProcessing(ctx)) {
+                    ChannelFuture f = ctx.writeAndFlush(new Ack(Protocol.VERSION_2, 0));
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("sending keep alive ack to libbeat");
+                        f.addListener((ChannelFutureListener) future -> {
+                            if (future.isSuccess()) {
+                                logger.trace("acking was successful");
+                            } else {
+                                logger.trace("acking failed");
+                            }
+                        });
+                    }
+                }
+            } else if (e.state() == IdleState.ALL_IDLE) {
+                logger.debug("reader and writer are idle, closing remote connection");
+                ctx.flush();
+                ChannelFuture f = ctx.close();
+                f.addListener((future) ->{
+                   if (future.isSuccess()){
+                       logger.warn("success");
+                   } else {
+                        logger.warn("could not close the ctx");
+                   }
+                });
+            }
+        }
+    }
+
+    public boolean isProcessing(ChannelHandlerContext ctx) {
+        return ctx.channel().attr(BeatsHandler.PROCESSING_BATCH).get();
+    }
+}

--- a/src/main/java/org/logstash/beats/Server.java
+++ b/src/main/java/org/logstash/beats/Server.java
@@ -10,7 +10,6 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import io.netty.util.concurrent.EventExecutorGroup;
-import io.netty.util.concurrent.Future;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.logstash.netty.SslSimpleBuilder;
@@ -18,7 +17,6 @@ import org.logstash.netty.SslSimpleBuilder;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
-import java.util.concurrent.TimeUnit;
 
 
 
@@ -28,23 +26,23 @@ public class Server {
     private static final int DEFAULT_CLIENT_TIMEOUT_SECONDS = 15;
 
     private final int port;
-    private final NioEventLoopGroup bossGroup;
     private final NioEventLoopGroup workGroup;
     private final String host;
+    private final int beatsHeandlerThreadCount;
     private IMessageListener messageListener = new MessageListener();
     private SslSimpleBuilder sslBuilder;
 
     private final int clientInactivityTimeoutSeconds;
 
     public Server(String host, int p) {
-        this(host, p, DEFAULT_CLIENT_TIMEOUT_SECONDS);
+        this(host, p, DEFAULT_CLIENT_TIMEOUT_SECONDS, Runtime.getRuntime().availableProcessors() * 4);
     }
 
-    public Server(String host, int p, int timeout) {
+    public Server(String host, int p, int timeout, int threadCount) {
         this.host = host;
         port = p;
         clientInactivityTimeoutSeconds = timeout;
-        bossGroup = new NioEventLoopGroup();
+        beatsHeandlerThreadCount = threadCount;
         workGroup = new NioEventLoopGroup();
     }
 
@@ -58,10 +56,10 @@ public class Server {
         try {
             logger.info("Starting server on port: " +  this.port);
 
-            beatsInitializer = new BeatsInitializer(isSslEnable(), messageListener, clientInactivityTimeoutSeconds);
+            beatsInitializer = new BeatsInitializer(isSslEnable(), messageListener, clientInactivityTimeoutSeconds, beatsHeandlerThreadCount);
 
             ServerBootstrap server = new ServerBootstrap();
-            server.group(bossGroup, workGroup)
+            server.group(workGroup)
                     .channel(NioServerSocketChannel.class)
                     .childOption(ChannelOption.SO_LINGER, 0) // Since the protocol doesn't support yet a remote close from the server and we don't want to have 'unclosed' socket lying around we have to use `SO_LINGER` to force the close of the socket.
                     .childHandler(beatsInitializer);
@@ -69,7 +67,6 @@ public class Server {
             Channel channel = server.bind(host, port).sync().channel();
             channel.closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully().sync();
             workGroup.shutdownGracefully().sync();
             beatsInitializer.shutdownEventExecutor();
         }
@@ -79,10 +76,7 @@ public class Server {
 
     public void stop() throws InterruptedException {
         logger.debug("Server shutting down");
-
-        bossGroup.shutdownGracefully().sync();
         workGroup.shutdownGracefully().sync();
-
         logger.debug("Server stopped");
     }
 
@@ -97,16 +91,19 @@ public class Server {
     private class BeatsInitializer extends ChannelInitializer<SocketChannel> {
         private final String LOGGER_HANDLER = "logger";
         private final String SSL_HANDLER = "ssl-handler";
+        private final String IDLESTATE_HANDLER = "idlestate-handler";
         private final String KEEP_ALIVE_HANDLER = "keep-alive-handler";
         private final String BEATS_PARSER = "beats-parser";
         private final String BEATS_HANDLER = "beats-handler";
         private final String BEATS_ACKER = "beats-acker";
+
 
         private final int DEFAULT_IDLESTATEHANDLER_THREAD = 4;
         private final int IDLESTATE_WRITER_IDLE_TIME_SECONDS = 5;
         private final int IDLESTATE_ALL_IDLE_TIME_SECONDS = 0;
 
         private final EventExecutorGroup idleExecutorGroup;
+        private final EventExecutorGroup beatsHandlerExecutorGroup;
         private final IMessageListener message;
         private int clientInactivityTimeoutSeconds;
         private final LoggingHandler loggingHandler = new LoggingHandler();
@@ -114,11 +111,13 @@ public class Server {
 
         private boolean enableSSL = false;
 
-        public BeatsInitializer(Boolean secure, IMessageListener messageListener, int clientInactivityTimeoutSeconds) {
+        public BeatsInitializer(Boolean secure, IMessageListener messageListener, int clientInactivityTimeoutSeconds, int beatsHandlerThread) {
             enableSSL = secure;
             this.message = messageListener;
             this.clientInactivityTimeoutSeconds = clientInactivityTimeoutSeconds;
             idleExecutorGroup = new DefaultEventExecutorGroup(DEFAULT_IDLESTATEHANDLER_THREAD);
+            beatsHandlerExecutorGroup = new DefaultEventExecutorGroup(beatsHandlerThread);
+
         }
 
         public void initChannel(SocketChannel socket) throws IOException, NoSuchAlgorithmException, CertificateException {
@@ -130,15 +129,11 @@ public class Server {
                 SslHandler sslHandler = sslBuilder.build(socket.alloc());
                 pipeline.addLast(SSL_HANDLER, sslHandler);
             }
-
-            // We have set a specific executor for the idle check, because the `beatsHandler` can be
-            // blocked on the queue, this the idleStateHandler manage the `KeepAlive` signal.
-            pipeline.addLast(idleExecutorGroup, KEEP_ALIVE_HANDLER, new IdleStateHandler(clientInactivityTimeoutSeconds, IDLESTATE_WRITER_IDLE_TIME_SECONDS , IDLESTATE_ALL_IDLE_TIME_SECONDS));
-
-            pipeline.addLast(BEATS_PARSER, new BeatsParser());
+            pipeline.addLast(idleExecutorGroup, IDLESTATE_HANDLER, new IdleStateHandler(clientInactivityTimeoutSeconds, IDLESTATE_WRITER_IDLE_TIME_SECONDS , clientInactivityTimeoutSeconds));
             pipeline.addLast(BEATS_ACKER, new AckEncoder());
-            pipeline.addLast(BEATS_HANDLER, new BeatsHandler(this.message));
-
+            pipeline.addLast(KEEP_ALIVE_HANDLER, new KeepAliveHandler());
+            pipeline.addLast(BEATS_PARSER, new BeatsParser());
+            pipeline.addLast(beatsHandlerExecutorGroup, BEATS_HANDLER, new BeatsHandler(this.message));
         }
 
         @Override

--- a/src/test/java/org/logstash/beats/ServerTest.java
+++ b/src/test/java/org/logstash/beats/ServerTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static java.lang.Thread.currentThread;
 import static java.lang.Thread.sleep;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -32,6 +33,7 @@ public class ServerTest {
     private int randomPort;
     private EventLoopGroup group;
     private final String host = "0.0.0.0";
+    private final int threadCount = 10;
 
     @Before
     public void setUp() {
@@ -48,7 +50,7 @@ public class ServerTest {
 
         final CountDownLatch latch = new CountDownLatch(concurrentConnections);
 
-        final Server server = new Server(host, randomPort, inactivityTime);
+        final Server server = new Server(host, randomPort, inactivityTime, threadCount);
         final AtomicBoolean otherCause = new AtomicBoolean(false);
         server.setMessageListener(new MessageListener() {
             public void onNewConnection(ChannelHandlerContext ctx) {
@@ -112,7 +114,7 @@ public class ServerTest {
 
         final CountDownLatch latch = new CountDownLatch(concurrentConnections);
         final AtomicBoolean exceptionClose = new AtomicBoolean(false);
-        final Server server = new Server(host, randomPort, inactivityTime);
+        final Server server = new Server(host, randomPort, inactivityTime, threadCount);
         server.setMessageListener(new MessageListener() {
             @Override
             public void onNewConnection(ChannelHandlerContext ctx) {
@@ -168,7 +170,7 @@ public class ServerTest {
 
     @Test
     public void testServerShouldAcceptConcurrentConnection() throws InterruptedException {
-        final Server server = new Server(host, randomPort, 30);
+        final Server server = new Server(host, randomPort, 30, threadCount);
         SpyListener listener = new SpyListener();
         server.setMessageListener(listener);
         Runnable serverTask = new Runnable() {


### PR DESCRIPTION
We were using two differents NioEventLoop in the beats input, this was
 causing problems in the context of back pressure. When the NioEventLoop
 responsable of inserted to the queue was blocked we were still accepting
 new connection instead of refusing them. Creating a large amount of
 socket in the `CLOSE_WAIT` state.
    
`CLOSE_WAIT` state could also happen when an exception was raised,
 because we were flushing to the queue before closing the connection, now
 we close the connection first and flush to the queue. This can result in
 a blocked thread for some time but will reduce the connection.
This problem should only happen when using a buffering codec like the
 multiline codec.
    
We also fix an issue when the Main NioEventLoop was blocked, the keep alive signal were not send back to the client, making the beats handlers run into a separate executor allow the loop to send the keep alive signal.
 
Fixes #272