### PR TITLE
Upgrade to Netty 4.1.18 with tcnative 2.0.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ dependencies {
     testCompile 'org.hamcrest:hamcrest-library:1.3'
     testCompile 'org.apache.logging.log4j:log4j-core:2.6.2'
 
-    compile 'io.netty:netty-all:4.1.3.Final'
-    compile 'io.netty:netty-tcnative-boringssl-static:1.1.33.Fork23'
+    compile 'io.netty:netty-all:4.1.18.Final'
+    compile 'io.netty:netty-tcnative-boringssl-static:2.0.7.Final'
     compile 'org.javassist:javassist:3.20.0-GA'
     compile 'com.fasterxml.jackson.core:jackson-core:2.7.5'
     compile 'com.fasterxml.jackson.core:jackson-annotations:2.7.5'


### PR DESCRIPTION
Refer to http://netty.io/news/ for Netty release notes.

Closes #175 