### PR TITLE
Re-order pipeline to avoid NPE in KeepAliveHandler

### DIFF
--- a/src/main/java/org/logstash/beats/BeatsHandler.java
+++ b/src/main/java/org/logstash/beats/BeatsHandler.java
@@ -82,7 +82,12 @@ public class BeatsHandler extends SimpleChannelInboundHandler<Batch> {
             messageListener.onException(ctx, cause);
         }
 
-        logger.info(format("Exception: " + cause.getMessage()));
+        String causeMessage = cause.getMessage() == null ? cause.getClass().toString() : cause.getMessage();
+
+        if (logger.isDebugEnabled()){
+            logger.debug(format("Handling exception: " + causeMessage), cause);
+        }
+        logger.info(format("Handling exception: " + causeMessage));
     }
 
     private boolean needAck(Message message) {

--- a/src/main/java/org/logstash/beats/Server.java
+++ b/src/main/java/org/logstash/beats/Server.java
@@ -131,9 +131,9 @@ public class Server {
             }
             pipeline.addLast(idleExecutorGroup, IDLESTATE_HANDLER, new IdleStateHandler(clientInactivityTimeoutSeconds, IDLESTATE_WRITER_IDLE_TIME_SECONDS , clientInactivityTimeoutSeconds));
             pipeline.addLast(BEATS_ACKER, new AckEncoder());
-            pipeline.addLast(KEEP_ALIVE_HANDLER, new KeepAliveHandler());
             pipeline.addLast(BEATS_PARSER, new BeatsParser());
             pipeline.addLast(beatsHandlerExecutorGroup, BEATS_HANDLER, new BeatsHandler(this.message));
+            pipeline.addLast(KEEP_ALIVE_HANDLER, new KeepAliveHandler());
         }
 
         @Override


### PR DESCRIPTION
Move the KeepAliveHandler after the BeatsHandler to avoid cases
under load where #isProcessing is called on the KeepAliveHandler
before the 'BATCH_PROCESSING' property is set in BeatsHandler,
which can cause a NullPointerException to be thrown

Also:
 Update #exceptionCaught to show the exception class if no message
is available, and to show the stack trace in the debug log.

Fixes #282

  