### PR TITLE
Backport: Memory management and back pressure improvements

### DIFF
--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -122,7 +122,7 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
   config :client_inactivity_timeout, :validate => :number, :default => 60
 
   # Beats handler executor thread
-  config :executor_threads, :validate => :number, :default => LogStash::Config::CpuCoreStrategy.maximum * 4
+  config :executor_threads, :validate => :number, :default => LogStash::Config::CpuCoreStrategy.maximum
 
   def register
     # For Logstash 2.4 we need to make sure that the logger is correctly set for the

--- a/lib/logstash/inputs/beats/message_listener.rb
+++ b/lib/logstash/inputs/beats/message_listener.rb
@@ -27,20 +27,27 @@ module LogStash module Inputs class Beats
     end
 
     def onNewMessage(ctx, message)
-      hash = message.getData()
+      begin
+         hash = message.getData()
 
       target_field = extract_target_field(hash)
 
-      if target_field.nil?
-        event = LogStash::Event.new(hash)
-        @nocodec_transformer.transform(event)
-        @queue << event
-      else
-        codec(ctx).accept(CodecCallbackListener.new(target_field,
-                                                    hash,
-                                                    message.getIdentityStream(),
-                                                    @codec_transformer,
-                                                    @queue))
+        if target_field.nil?
+          event = LogStash::Event.new(hash)
+          @nocodec_transformer.transform(event)
+          @queue << event
+        else
+          codec(ctx).accept(CodecCallbackListener.new(target_field,
+                                                      hash,
+                                                      message.getIdentityStream(),
+                                                      @codec_transformer,
+                                                      @queue))
+        end
+      rescue => e
+        logger.warn("Error handling message #{message}", e)
+        raise e
+      ensure
+        message.release
       end
     end
 
@@ -75,6 +82,11 @@ module LogStash module Inputs class Beats
     def codec(ctx)
       return if connections_list[ctx].nil?
       connections_list[ctx].codec
+    end
+
+    def ip_address(ctx)
+      return if connections_list[ctx].nil?
+      connections_list[ctx].ip_address
     end
 
     def register_connection(ctx)

--- a/lib/logstash/inputs/beats/message_listener.rb
+++ b/lib/logstash/inputs/beats/message_listener.rb
@@ -27,27 +27,20 @@ module LogStash module Inputs class Beats
     end
 
     def onNewMessage(ctx, message)
-      begin
-         hash = message.getData()
+      hash = message.getData()
 
       target_field = extract_target_field(hash)
 
-        if target_field.nil?
-          event = LogStash::Event.new(hash)
-          @nocodec_transformer.transform(event)
-          @queue << event
-        else
-          codec(ctx).accept(CodecCallbackListener.new(target_field,
-                                                      hash,
-                                                      message.getIdentityStream(),
-                                                      @codec_transformer,
-                                                      @queue))
-        end
-      rescue => e
-        logger.warn("Error handling message #{message}", e)
-        raise e
-      ensure
-        message.release
+      if target_field.nil?
+        event = LogStash::Event.new(hash)
+        @nocodec_transformer.transform(event)
+        @queue << event
+      else
+        codec(ctx).accept(CodecCallbackListener.new(target_field,
+                                                    hash,
+                                                    message.getIdentityStream(),
+                                                    @codec_transformer,
+                                                    @queue))
       end
     end
 
@@ -82,11 +75,6 @@ module LogStash module Inputs class Beats
     def codec(ctx)
       return if connections_list[ctx].nil?
       connections_list[ctx].codec
-    end
-
-    def ip_address(ctx)
-      return if connections_list[ctx].nil?
-      connections_list[ctx].ip_address
     end
 
     def register_connection(ctx)

--- a/spec/integration/logstash_forwarder_spec.rb
+++ b/spec/integration/logstash_forwarder_spec.rb
@@ -55,7 +55,6 @@ describe "Logstash-Forwarder", :integration => true do
       f.write(events.join("\n") + "\n")
     end
     sleep(1) # give some time to the clients to pick up the changes
-    stop_client
   end
 
   after :each do

--- a/src/main/java/org/logstash/beats/Batch.java
+++ b/src/main/java/org/logstash/beats/Batch.java
@@ -1,47 +1,48 @@
 package org.logstash.beats;
 
-import java.util.ArrayList;
-import java.util.List;
+/**
+ * Interface representing a Batch of {@link Message}.
+ */
+public interface Batch extends Iterable<Message>{
+    /**
+     * Returns the protocol of the sent messages that this batch was constructed from
+     * @return byte - either '1' or '2'
+     */
+    byte getProtocol();
 
-public class Batch {
-    private byte protocol = Protocol.VERSION_2;
-    private int batchSize;
-    private List<Message> messages = new ArrayList();
+    /**
+     * Number of messages that the batch is expected to contain.
+     * @return int  - number of messages
+     */
+    int getBatchSize();
 
-    public List<Message> getMessages() {
-        return messages;
-    }
+    /**
+     * Set the number of messages that the batch is expected to contain.
+     * @param batchSize int - number of messages
+     */
+    void setBatchSize(int batchSize);
 
-    public void addMessage(Message message) {
-        message.setBatch(this);
-        messages.add(message);
-    }
+    /**
+     * Current number of messages in the batch
+     * @return int
+     */
+    int size();
 
-    public int size() {
-        return messages.size();
-    }
+    /**
+     * Is the batch currently empty?
+     * @return boolean
+     */
+    boolean isEmpty();
 
-    public void setBatchSize(int size) {
-        batchSize = size;
-    }
+    /**
+     * Is the batch complete?
+     * @return boolean
+     */
+    boolean isComplete();
 
-    public int getBatchSize() {
-        return batchSize;
-    }
-
-    public boolean isEmpty() {
-        return 0 == messages.size();
-    }
-
-    public boolean complete() {
-        return size() == getBatchSize();
-    }
-
-    public byte getProtocol() {
-        return protocol;
-    }
-
-    public void setProtocol(byte protocol) {
-        this.protocol = protocol;
-    }
+    /**
+     * Release the resources associated with the batch. Consumers of the batch *must* release
+     * after use.
+     */
+    void release();
 }

--- a/src/main/java/org/logstash/beats/KeepAliveHandler.java
+++ b/src/main/java/org/logstash/beats/KeepAliveHandler.java
@@ -23,6 +23,7 @@ public class KeepAliveHandler extends ChannelDuplexHandler {
             if (e.state() == IdleState.WRITER_IDLE) {
                 if (isProcessing(ctx)) {
                     ChannelFuture f = ctx.writeAndFlush(new Ack(Protocol.VERSION_2, 0));
+                    logger.warn("sending keep alive ack to libbeat");
                     if (logger.isTraceEnabled()) {
                         logger.trace("sending keep alive ack to libbeat");
                         f.addListener(new ChannelFutureListener() {
@@ -59,6 +60,6 @@ public class KeepAliveHandler extends ChannelDuplexHandler {
     }
 
     public boolean isProcessing(ChannelHandlerContext ctx) {
-        return ctx.channel().attr(BeatsHandler.PROCESSING_BATCH).get();
+        return ctx.channel().hasAttr(BeatsHandler.PROCESSING_BATCH) && ctx.channel().attr(BeatsHandler.PROCESSING_BATCH).get();
     }
 }

--- a/src/main/java/org/logstash/beats/KeepAliveHandler.java
+++ b/src/main/java/org/logstash/beats/KeepAliveHandler.java
@@ -16,14 +16,13 @@ public class KeepAliveHandler extends ChannelDuplexHandler {
 
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-        IdleStateEvent e = null;
+        IdleStateEvent e;
 
         if (evt instanceof IdleStateEvent) {
             e = (IdleStateEvent) evt;
             if (e.state() == IdleState.WRITER_IDLE) {
                 if (isProcessing(ctx)) {
                     ChannelFuture f = ctx.writeAndFlush(new Ack(Protocol.VERSION_2, 0));
-                    logger.warn("sending keep alive ack to libbeat");
                     if (logger.isTraceEnabled()) {
                         logger.trace("sending keep alive ack to libbeat");
                         f.addListener(new ChannelFutureListener() {
@@ -59,7 +58,7 @@ public class KeepAliveHandler extends ChannelDuplexHandler {
         }
     }
 
-    public boolean isProcessing(ChannelHandlerContext ctx) {
+     public boolean isProcessing(ChannelHandlerContext ctx) {
         return ctx.channel().hasAttr(BeatsHandler.PROCESSING_BATCH) && ctx.channel().attr(BeatsHandler.PROCESSING_BATCH).get();
     }
 }

--- a/src/main/java/org/logstash/beats/Message.java
+++ b/src/main/java/org/logstash/beats/Message.java
@@ -1,29 +1,63 @@
 package org.logstash.beats;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 public class Message implements Comparable<Message> {
     private final int sequence;
     private String identityStream;
-    private final Map data;
+    private Map data;
     private Batch batch;
+    private ByteBuf buffer;
+    private Logger logger = LogManager.getLogger(Message.class);
+
+    public final static ObjectMapper MAPPER = new ObjectMapper().registerModule(new AfterburnerModule());
 
     public Message(int sequence, Map map) {
         this.sequence = sequence;
         this.data = map;
+    }
 
-        identityStream = extractIdentityStream();
+    public Message(int sequence, ByteBuf buffer){
+        this.sequence = sequence;
+        this.buffer = buffer;
     }
 
     public int getSequence() {
         return sequence;
     }
 
+    public boolean release() {
+        if (buffer != null){
+            return buffer.release();
+        }
+        return true;
+    }
 
-    public Map getData() {
+    public Map getData(){
+        if (data == null && buffer != null){
+            try (ByteBufInputStream byteBufInputStream = new ByteBufInputStream(buffer)){
+                data = (Map)MAPPER.readValue(byteBufInputStream, Object.class);
+            } catch (IOException e){
+                throw new RuntimeException("Unable to parse beats payload ", e);
+            }
+//            finally{
+//                release();
+//            }
+        }
+
         return data;
     }
+
+    private NewBatch newBatch;
 
     @Override
     public int compareTo(Message o) {
@@ -38,7 +72,19 @@ public class Message implements Comparable<Message> {
         batch = newBatch;
     }
 
+    public NewBatch getNewBatch() {
+        return newBatch;
+    }
+
+    public void setNewBatch(NewBatch newnewBatch){
+        this.newBatch = newnewBatch;
+    }
+
+
     public String getIdentityStream() {
+        if (identityStream == null){
+            identityStream = extractIdentityStream();
+        }
         return identityStream;
     }
 
@@ -52,7 +98,7 @@ public class Message implements Comparable<Message> {
             if(id != null && resourceId != null) {
                 return id + "-" + resourceId;
             } else {
-                return (String) beatsData.get("name") + "-" + (String) beatsData.get("source");
+                return beatsData.get("name") + "-" + beatsData.get("source");
             }
         }
 

--- a/src/main/java/org/logstash/beats/Runner.java
+++ b/src/main/java/org/logstash/beats/Runner.java
@@ -7,6 +7,7 @@ import org.logstash.netty.SslSimpleBuilder;
 
 public class Runner {
     private static final int DEFAULT_PORT = 5044;
+
     private final static Logger logger = LogManager.getLogger(Runner.class);
 
 
@@ -17,7 +18,7 @@ public class Runner {
         // Check for leaks.
         // ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.PARANOID);
 
-        Server server = new Server("0.0.0.0", DEFAULT_PORT);
+        Server server = new Server("0.0.0.0", DEFAULT_PORT, 15, Runtime.getRuntime().availableProcessors());
 
             if(args.length > 0 && args[0].equals("ssl")) {
             logger.debug("Using SSL");

--- a/src/main/java/org/logstash/beats/Server.java
+++ b/src/main/java/org/logstash/beats/Server.java
@@ -23,8 +23,6 @@ import java.util.concurrent.TimeUnit;
 public class Server {
     private final static Logger logger = LogManager.getLogger(Server.class);
 
-    private static final int DEFAULT_CLIENT_TIMEOUT_SECONDS = 15;
-
     private final int port;
     private final NioEventLoopGroup workGroup;
     private final String host;
@@ -36,13 +34,12 @@ public class Server {
     private final int clientInactivityTimeoutSeconds;
 
     public Server(String host, int p, int timeout, int threadCount) {
-
         this.host = host;
         port = p;
         clientInactivityTimeoutSeconds = timeout;
         beatsHeandlerThreadCount = threadCount;
         workGroup = new NioEventLoopGroup();
-   }
+    }
 
     public void enableSSL(SslSimpleBuilder builder) {
         sslBuilder = builder;
@@ -50,7 +47,7 @@ public class Server {
 
     public Server listen() throws InterruptedException {
         try {
-            logger.info("Starting server on port: " + this.port);
+            logger.info("Starting server on port: " +  this.port);
 
             beatsInitializer = new BeatsInitializer(isSslEnable(), messageListener, clientInactivityTimeoutSeconds, beatsHeandlerThreadCount);
 
@@ -97,8 +94,6 @@ public class Server {
         private final String SSL_HANDLER = "ssl-handler";
         private final String IDLESTATE_HANDLER = "idlestate-handler";
         private final String KEEP_ALIVE_HANDLER = "keep-alive-handler";
-        private final String BEATS_PARSER = "beats-parser";
-        private final String BEATS_HANDLER = "beats-handler";
         private final String BEATS_ACKER = "beats-acker";
 
 

--- a/src/main/java/org/logstash/beats/V1Batch.java
+++ b/src/main/java/org/logstash/beats/V1Batch.java
@@ -1,0 +1,69 @@
+package org.logstash.beats;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Implementation of {@link Batch} intended for batches constructed from v1 protocol
+ *
+ */
+public class V1Batch implements Batch{
+
+    private int batchSize;
+    private List<Message> messages = new ArrayList<>();
+    private byte protocol = Protocol.VERSION_1;
+
+    @Override
+    public byte getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(byte protocol){
+        this.protocol = protocol;
+    }
+
+    /**
+     * Add Message to the batch
+     * @param message Message to add to the batch
+     */
+    void addMessage(Message message){
+        message.setBatch(this);
+        messages.add(message);
+    }
+
+    @Override
+    public Iterator<Message> iterator(){
+        return messages.iterator();
+    }
+
+    @Override
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    @Override
+    public void setBatchSize(int batchSize){
+        this.batchSize = batchSize;
+    }
+
+    @Override
+    public int size() {
+        return messages.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return 0 == messages.size();
+    }
+
+    @Override
+    public boolean isComplete() {
+        return size() == getBatchSize();
+    }
+
+    @Override
+    public void release() {
+        //no-op
+    }
+}

--- a/src/main/java/org/logstash/beats/V2Batch.java
+++ b/src/main/java/org/logstash/beats/V2Batch.java
@@ -1,0 +1,95 @@
+package org.logstash.beats;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+
+import java.util.Iterator;
+
+/**
+ * Implementation of {@link Batch} for the v2 protocol backed by ByteBuf. *must* be released after use.
+ */
+public class V2Batch implements Batch {
+    private ByteBuf internalBuffer = PooledByteBufAllocator.DEFAULT.buffer();
+    private int written = 0;
+    private int read = 0;
+    private static final int SIZE_OF_INT = 4;
+    private int batchSize;
+
+    public void setProtocol(byte protocol){
+        if (protocol != Protocol.VERSION_2){
+            throw new IllegalArgumentException("Only version 2 protocol is supported");
+        }
+    }
+
+    @Override
+    public byte getProtocol() {
+        return Protocol.VERSION_2;
+    }
+
+    public Iterator<Message> iterator(){
+        internalBuffer.resetReaderIndex();
+        return new Iterator<Message>() {
+            @Override
+            public boolean hasNext() {
+                return read < written;
+            }
+
+            @Override
+            public Message next() {
+                int sequenceNumber = internalBuffer.readInt();
+                int readableBytes = internalBuffer.readInt();
+                Message message = new Message(sequenceNumber, internalBuffer.slice(internalBuffer.readerIndex(), readableBytes));
+                internalBuffer.readerIndex(internalBuffer.readerIndex() + readableBytes);
+                message.setBatch(V2Batch.this);
+                read++;
+                return message;
+            }
+        };
+    }
+
+    @Override
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    @Override
+    public void setBatchSize(final int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    @Override
+    public int size() {
+        return written;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return written == 0;
+    }
+
+    @Override
+    public boolean isComplete() {
+        return written == batchSize;
+    }
+
+    /**
+     * Adds a message to the batch, which will be constructed into an actual {@link Message} lazily.
+      * @param sequenceNumber sequence number of the message within the batch
+     * @param buffer A ByteBuf pointing to serialized JSon
+     * @param size size of the serialized Json
+     */
+    void addMessage(int sequenceNumber, ByteBuf buffer, int size) {
+        written++;
+        if (internalBuffer.writableBytes() < size + (2 * SIZE_OF_INT)){
+            internalBuffer.capacity(internalBuffer.capacity() + size + (2 * SIZE_OF_INT));
+        }
+        internalBuffer.writeInt(sequenceNumber);
+        internalBuffer.writeInt(size);
+        buffer.readBytes(internalBuffer, size);
+    }
+
+    @Override
+    public void release() {
+        internalBuffer.release();
+    }
+}

--- a/src/test/java/org/logstash/beats/BatchEncoder.java
+++ b/src/test/java/org/logstash/beats/BatchEncoder.java
@@ -40,7 +40,7 @@ public class BatchEncoder extends MessageToByteEncoder<Batch> {
         ByteBuf payload = ctx.alloc().buffer();
 
         // Aggregates the payload that we could decide to compress or not.
-        for(Message message : batch.getMessages()) {
+        for(Message message : batch) {
             if (batch.getProtocol() == Protocol.VERSION_2) {
                 encodeMessageWithJson(payload, message);
             } else {
@@ -55,7 +55,7 @@ public class BatchEncoder extends MessageToByteEncoder<Batch> {
         payload.writeByte('J');
         payload.writeInt(message.getSequence());
 
-        byte[] json = BeatsParser.MAPPER.writeValueAsBytes(message.getData());
+        byte[] json = Message.MAPPER.writeValueAsBytes(message.getData());
         payload.writeInt(json.length);
         payload.writeBytes(json);
     }

--- a/src/test/java/org/logstash/beats/BeatsHandlerTest.java
+++ b/src/test/java/org/logstash/beats/BeatsHandlerTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertTrue;
 public class BeatsHandlerTest {
     private SpyListener spyListener;
     private BeatsHandler beatsHandler;
-    private Batch batch;
+    private V1Batch batch;
 
     private class SpyListener implements IMessageListener {
         private boolean onNewConnectionCalled = false;
@@ -79,9 +79,8 @@ public class BeatsHandlerTest {
         Message message1 = new Message(1, new HashMap());
         Message message2 = new Message(2, new HashMap());
 
-        batch = new Batch();
+        batch = new V1Batch();
         batch.setBatchSize(2);
-        batch.setProtocol(Protocol.VERSION_1);
         batch.addMessage(message1);
         batch.addMessage(message2);
 
@@ -119,7 +118,6 @@ public class BeatsHandlerTest {
     public void TestItAckLastMessageFromBatch() {
         EmbeddedChannel embeddedChannel = new EmbeddedChannel(new BeatsHandler(spyListener));
         embeddedChannel.writeInbound(batch);
-
 
         embeddedChannel.close();
     }

--- a/src/test/java/org/logstash/beats/V1BatchTest.java
+++ b/src/test/java/org/logstash/beats/V1BatchTest.java
@@ -7,12 +7,12 @@ import java.util.HashMap;
 
 import static org.junit.Assert.*;
 
-public class BatchTest {
-    private Batch batch;
+public class V1BatchTest {
+    private V1Batch batch;
 
     @Before
     public void setUp() {
-        batch = new Batch();
+        batch = new V1Batch();
     }
 
     @Test
@@ -30,13 +30,7 @@ public class BatchTest {
     }
 
     @Test
-    public void TestGetDefaultProtocol() {
-        assertEquals(Protocol.VERSION_2, batch.getProtocol());
-    }
-
-    @Test
-    public void TestGetSetProtocol() {
-        batch.setProtocol(Protocol.VERSION_1);
+    public void TestGetProtocol() {
         assertEquals(Protocol.VERSION_1, batch.getProtocol());
     }
 
@@ -46,11 +40,11 @@ public class BatchTest {
 
         batch.setBatchSize(numberOfEvent);
 
-        for(int i = 0; i < numberOfEvent; i++) {
-            batch.addMessage(new Message(i + 1, new HashMap()));
+        for(int i = 1; i <= numberOfEvent; i++) {
+            batch.addMessage(new Message(i, new HashMap()));
         }
 
-        assertTrue(batch.complete());
+        assertTrue(batch.isComplete());
     }
 
     @Test
@@ -61,6 +55,6 @@ public class BatchTest {
 
         batch.addMessage(new Message(1, new HashMap()));
 
-        assertFalse(batch.complete());
+        assertFalse(batch.isComplete());
     }
 }

--- a/src/test/java/org/logstash/beats/V2BatchTest.java
+++ b/src/test/java/org/logstash/beats/V2BatchTest.java
@@ -1,0 +1,101 @@
+package org.logstash.beats;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class V2BatchTest {
+    public final static ObjectMapper MAPPER = new ObjectMapper().registerModule(new AfterburnerModule());
+
+    @Test
+    public void testIsEmpty() {
+        V2Batch batch = new V2Batch();
+        assertTrue(batch.isEmpty());
+        ByteBuf content = messageContents();
+        batch.addMessage(1, content, content.readableBytes());
+        assertFalse(batch.isEmpty());
+    }
+
+    @Test
+    public void testSize() {
+        V2Batch batch = new V2Batch();
+        assertEquals(0, batch.size());
+        ByteBuf content = messageContents();
+        batch.addMessage(1, content, content.readableBytes());
+        assertEquals(1, batch.size());
+    }
+
+    @Test
+    public void TestGetProtocol() {
+        assertEquals(Protocol.VERSION_2, new V2Batch().getProtocol());
+    }
+
+    @Test
+    public void TestCompleteReturnTrueWhenIReceiveTheSameAmountOfEvent() {
+        V2Batch batch = new V2Batch();
+        int numberOfEvent = 2;
+
+        batch.setBatchSize(numberOfEvent);
+
+        for(int i = 1; i <= numberOfEvent; i++) {
+            ByteBuf content = messageContents();
+            batch.addMessage(i, content, content.readableBytes());
+        }
+
+        assertTrue(batch.isComplete());
+    }
+
+    @Test
+    public void testBigBatch() {
+        V2Batch batch = new V2Batch();
+        int size = 4096;
+        assertEquals(0, batch.size());
+        try {
+            ByteBuf content = messageContents();
+            for (int i = 0; i < size; i++) {
+                batch.addMessage(i, content, content.readableBytes());
+            }
+            assertEquals(size, batch.size());
+            int i = 0;
+            for (Message message : batch) {
+                assertEquals(message.getSequence(), i++);
+            }
+        }finally {
+            batch.release();
+        }
+    }
+
+
+    @Test
+    public void TestCompleteReturnWhenTheNumberOfEventDoesntMatchBatchSize() {
+        V2Batch batch = new V2Batch();
+        int numberOfEvent = 2;
+
+        batch.setBatchSize(numberOfEvent);
+        ByteBuf content = messageContents();
+        batch.addMessage(1, content, content.readableBytes());
+
+        assertFalse(batch.isComplete());
+    }
+
+    public static ByteBuf messageContents() {
+        Map test = new HashMap();
+        test.put("key", "value");
+        try {
+            byte[] bytes = MAPPER.writeValueAsBytes(test);
+            return Unpooled.wrappedBuffer(bytes);
+        } catch (Exception e){
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Backport of #299 to `3.x` branch:

The main intent of this commit is to mitigate the very high memory usage detailed in #286, by ensuring that the KeepAliveHandler works when Logstash queues are blocked, and improve the memory usage by using ByteBuf instances where possible, and deserializing as late as possible.

Also:
Reduces the default number of beats executor threads from
4*number_of_processors to number_of_processors
Includes fixes for #259
Fixes an integration test which was failing regularly on Travis
