### PR TITLE
3.x - Bump jackson dependency to 2.9.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,10 @@ dependencies {
     compile 'io.netty:netty-all:4.1.3.Final'
     compile 'io.netty:netty-tcnative-boringssl-static:1.1.33.Fork23'
     compile 'org.javassist:javassist:3.20.0-GA'
-    compile 'com.fasterxml.jackson.core:jackson-core:2.9.1'
-    compile 'com.fasterxml.jackson.core:jackson-annotations:2.9.1'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.9.1'
-    compile 'com.fasterxml.jackson.module:jackson-module-afterburner:2.9.1'
+    compile 'com.fasterxml.jackson.core:jackson-core:2.9.4'
+    compile 'com.fasterxml.jackson.core:jackson-annotations:2.9.4'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.9.4'
+    compile 'com.fasterxml.jackson.module:jackson-module-afterburner:2.9.4'
     compile 'org.apache.logging.log4j:log4j-api:2.6.2'
 
 }


### PR DESCRIPTION
3.x backport of https://github.com/logstash-plugins/logstash-input-beats/pull/305
