### PR TITLE
When log level is set to trace, format() was called before context was initiallized. Fixed

### DIFF
--- a/src/main/java/org/logstash/beats/BeatsHandler.java
+++ b/src/main/java/org/logstash/beats/BeatsHandler.java
@@ -21,11 +21,11 @@ public class BeatsHandler extends SimpleChannelInboundHandler<Batch> {
 
     @Override
     public void channelActive(final ChannelHandlerContext ctx) throws Exception {
+	context = ctx;
         if (logger.isTraceEnabled()){
             logger.trace(format("Channel Active"));
         }
         super.channelActive(ctx);
-        context = ctx;
         messageListener.onNewConnection(ctx);
     }
 


### PR DESCRIPTION


Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
