### PR TITLE
Add support to storing TLS client authentication in event's metadata

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -89,7 +89,7 @@ input plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-cipher_suites"]
-===== `cipher_suites` 
+===== `cipher_suites`
 
   * Value type is <<array,array>>
   * Default value is `java.lang.String[TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256]@459cfcca`
@@ -97,7 +97,7 @@ input plugins.
 The list of ciphers suite to use, listed by priorities.
 
 [id="plugins-{type}s-{plugin}-client_inactivity_timeout"]
-===== `client_inactivity_timeout` 
+===== `client_inactivity_timeout`
 
   * Value type is <<number,number>>
   * Default value is `60`
@@ -105,7 +105,7 @@ The list of ciphers suite to use, listed by priorities.
 Close Idle clients after X seconds of inactivity.
 
 [id="plugins-{type}s-{plugin}-host"]
-===== `host` 
+===== `host`
 
   * Value type is <<string,string>>
   * Default value is `"0.0.0.0"`
@@ -113,7 +113,7 @@ Close Idle clients after X seconds of inactivity.
 The IP address to listen on.
 
 [id="plugins-{type}s-{plugin}-include_codec_tag"]
-===== `include_codec_tag` 
+===== `include_codec_tag`
 
   * Value type is <<boolean,boolean>>
   * Default value is `true`
@@ -121,7 +121,7 @@ The IP address to listen on.
 
 
 [id="plugins-{type}s-{plugin}-port"]
-===== `port` 
+===== `port`
 
   * This is a required setting.
   * Value type is <<number,number>>
@@ -130,7 +130,7 @@ The IP address to listen on.
 The port to listen on.
 
 [id="plugins-{type}s-{plugin}-ssl"]
-===== `ssl` 
+===== `ssl`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
@@ -140,7 +140,7 @@ enable encryption by setting `ssl` to true and configuring
 the `ssl_certificate` and `ssl_key` options.
 
 [id="plugins-{type}s-{plugin}-ssl_certificate"]
-===== `ssl_certificate` 
+===== `ssl_certificate`
 
   * Value type is <<path,path>>
   * There is no default value for this setting.
@@ -148,19 +148,19 @@ the `ssl_certificate` and `ssl_key` options.
 SSL certificate to use.
 
 [id="plugins-{type}s-{plugin}-ssl_certificate_authorities"]
-===== `ssl_certificate_authorities` 
+===== `ssl_certificate_authorities`
 
   * Value type is <<array,array>>
   * Default value is `[]`
 
-Validate client certificates against these authorities. 
+Validate client certificates against these authorities.
 You can define multiple files or paths. All the certificates will
 be read and added to the trust store. You need to configure the `ssl_verify_mode`
 to `peer` or `force_peer` to enable the verification.
 
 
 [id="plugins-{type}s-{plugin}-ssl_handshake_timeout"]
-===== `ssl_handshake_timeout` 
+===== `ssl_handshake_timeout`
 
   * Value type is <<number,number>>
   * Default value is `10000`
@@ -168,7 +168,7 @@ to `peer` or `force_peer` to enable the verification.
 Time in milliseconds for an incomplete ssl handshake to timeout
 
 [id="plugins-{type}s-{plugin}-ssl_key"]
-===== `ssl_key` 
+===== `ssl_key`
 
   * Value type is <<path,path>>
   * There is no default value for this setting.
@@ -178,7 +178,7 @@ NOTE: This key need to be in the PKCS8 format, you can convert it with https://w
 for more information.
 
 [id="plugins-{type}s-{plugin}-ssl_key_passphrase"]
-===== `ssl_key_passphrase` 
+===== `ssl_key_passphrase`
 
   * Value type is <<password,password>>
   * There is no default value for this setting.
@@ -186,14 +186,14 @@ for more information.
 SSL key passphrase to use.
 
 [id="plugins-{type}s-{plugin}-ssl_verify_mode"]
-===== `ssl_verify_mode` 
+===== `ssl_verify_mode`
 
   * Value can be any of: `none`, `peer`, `force_peer`
   * Default value is `"none"`
 
 By default the server doesn't do any client verification.
 
-`peer` will make the server ask the client to provide a certificate. 
+`peer` will make the server ask the client to provide a certificate.
 If the client provides a certificate, it will be validated.
 
 `force_peer` will make the server ask the client to provide a certificate.
@@ -202,17 +202,17 @@ If the client doesn't provide a certificate, the connection will be closed.
 This option needs to be used with `ssl_certificate_authorities` and a defined list of CAs.
 
 [id="plugins-{type}s-{plugin}-ssl_peer_metadata"]
-===== `ssl_peer_metadata` 
+===== `ssl_peer_metadata`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
 
 Enables storing client certificate information in event's metadata.
 
-This option needs to be used with `ssl_verify_mode` set to `peer` or `force_peer`.
+This option is only valid when `ssl_verify_mode` is set to `peer` or `force_peer`.
 
 [id="plugins-{type}s-{plugin}-tls_max_version"]
-===== `tls_max_version` 
+===== `tls_max_version`
 
   * Value type is <<number,number>>
   * Default value is `1.2`
@@ -221,7 +221,7 @@ The maximum TLS version allowed for the encrypted connections. The value must be
 1.0 for TLS 1.0, 1.1 for TLS 1.1, 1.2 for TLS 1.2
 
 [id="plugins-{type}s-{plugin}-tls_min_version"]
-===== `tls_min_version` 
+===== `tls_min_version`
 
   * Value type is <<number,number>>
   * Default value is `1`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -78,6 +78,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-ssl_key>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-ssl_key_passphrase>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-ssl_verify_mode>> |<<string,string>>, one of `["none", "peer", "force_peer"]`|No
+| <<plugins-{type}s-{plugin}-ssl_peer_metadata>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-tls_max_version>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-tls_min_version>> |<<number,number>>|No
 |=======================================================================
@@ -199,6 +200,16 @@ If the client provides a certificate, it will be validated.
 If the client doesn't provide a certificate, the connection will be closed.
 
 This option needs to be used with `ssl_certificate_authorities` and a defined list of CAs.
+
+[id="plugins-{type}s-{plugin}-ssl_peer_metadata"]
+===== `ssl_peer_metadata` 
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Enables storing client certificate information in event's metadata.
+
+This option needs to be used with `ssl_verify_mode` set to `peer` or `force_peer`.
 
 [id="plugins-{type}s-{plugin}-tls_max_version"]
 ===== `tls_max_version` 

--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -214,6 +214,10 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
     @ssl_peer_metadata && ssl_configured? && client_authentification? 
   end
 
+  def client_authentication_required?
+    @ssl_verify_mode == "force_peer" 
+  end
+
   def require_certificate_authorities?
     @ssl_verify_mode == "force_peer" || @ssl_verify_mode == "peer"
   end

--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -152,6 +152,10 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
       raise LogStash::ConfigurationError, "Using `verify_mode` set to PEER or FORCE_PEER, requires the configuration of `certificate_authorities`"
     end
 
+    if client_authentication_metadata? && !require_certificate_authorities?
+      raise LogStash::ConfigurationError, "Enabling `peer_metadata` requires using `verify_mode` set to PEER or FORCE_PEER"
+    end
+
     # Logstash 6.x breaking change (introduced with 4.0.0 of this gem)
     if @codec.kind_of? LogStash::Codecs::Multiline
       raise LogStash::ConfigurationError, "Multiline codec with beats input is not supported. Please refer to the beats documentation for how to best manage multiline data. See https://www.elastic.co/guide/en/beats/filebeat/current/multiline-examples.html"

--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -93,6 +93,10 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
   # This option needs to be used with `ssl_certificate_authorities` and a defined list of CAs.
   config :ssl_verify_mode, :validate => ["none", "peer", "force_peer"], :default => "none"
 
+  # Enables storing client certificate information in event's metadata. You need 
+  # to configure the `ssl_verify_mode` to `peer` or `force_peer` to enable this.
+  config :ssl_peer_metadata, :validate => :boolean, :default => false
+
   config :include_codec_tag, :validate => :boolean, :default => true
 
   # Time in milliseconds for an incomplete ssl handshake to timeout
@@ -204,6 +208,10 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
 
   def client_authentification?
     @ssl_certificate_authorities && @ssl_certificate_authorities.size > 0
+  end
+
+  def client_authentication_metadata?
+    @ssl_peer_metadata && ssl_configured? && client_authentification? 
   end
 
   def require_certificate_authorities?

--- a/lib/logstash/inputs/beats/message_listener.rb
+++ b/lib/logstash/inputs/beats/message_listener.rb
@@ -139,9 +139,10 @@ module LogStash module Inputs class Beats
 
         if tls_verified
           hash['@metadata']['tls_peer'] = {
-            :status     => "verified",
-            :protocol   => tls_session.getProtocol(),
-            :principal  => tls_session.getPeerPrincipal().getName()
+            :status       => "verified",
+            :protocol     => tls_session.getProtocol(),
+            :principal    => tls_session.getPeerPrincipal().getName(),
+            :cipher_suite => tls_session.getCipherSuite()
           }
         else
           hash['@metadata']['tls_peer'] = {

--- a/lib/logstash/inputs/beats/message_listener.rb
+++ b/lib/logstash/inputs/beats/message_listener.rb
@@ -134,7 +134,7 @@ module LogStash module Inputs class Beats
           rescue SSLPeerUnverifiedException => e
             tls_verified = false
             if input.logger.debug?
-              input.logger.warn("Failed to get peer certificates.", :exception => e.to_s)
+              input.logger.debug("SSL peer unverified. This is normal with 'peer' verification and client does not presents a certificate.", :exception => e.to_s)
             end
           end
         end

--- a/lib/logstash/inputs/beats/message_listener.rb
+++ b/lib/logstash/inputs/beats/message_listener.rb
@@ -141,9 +141,10 @@ module LogStash module Inputs class Beats
 
         if tls_verified
           hash['@metadata']['tls_peer'] = {
-            :status     => "verified",
-            :protocol   => tls_session.getProtocol(),
-            :principal  => tls_session.getPeerPrincipal().getName()
+            :status       => "verified",
+            :protocol     => tls_session.getProtocol(),
+            :principal    => tls_session.getPeerPrincipal().getName(),
+            :cipher_suite => tls_session.getCipherSuite()
           }
         else
           hash['@metadata']['tls_peer'] = {

--- a/lib/logstash/inputs/beats/message_listener.rb
+++ b/lib/logstash/inputs/beats/message_listener.rb
@@ -141,10 +141,9 @@ module LogStash module Inputs class Beats
 
         if tls_verified
           hash['@metadata']['tls_peer'] = {
-            :status       => "verified",
-            :protocol     => tls_session.getProtocol(),
-            :principal    => tls_session.getPeerPrincipal().getName(),
-            :cipher_suite => tls_session.getCipherSuite()
+            :status     => "verified",
+            :protocol   => tls_session.getProtocol(),
+            :principal  => tls_session.getPeerPrincipal().getName()
           }
         else
           hash['@metadata']['tls_peer'] = {

--- a/lib/logstash/inputs/beats/message_listener.rb
+++ b/lib/logstash/inputs/beats/message_listener.rb
@@ -134,7 +134,7 @@ module LogStash module Inputs class Beats
           rescue SSLPeerUnverifiedException => e
             tls_verified = false
             if input.logger.debug?
-              input.logger.debug("SSL peer unverified. This is normal with 'peer' verification and client does not presents a certificate.", :exception => e.to_s)
+              input.logger.debug("SSL peer unverified. This is normal with 'peer' verification and client does not presents a certificate.", :exception => e)
             end
           end
         end

--- a/lib/logstash/inputs/beats/message_listener.rb
+++ b/lib/logstash/inputs/beats/message_listener.rb
@@ -143,7 +143,7 @@ module LogStash module Inputs class Beats
           hash['@metadata']['tls_peer'] = {
             :status       => "verified",
             :protocol     => tls_session.getProtocol(),
-            :principal    => tls_session.getPeerPrincipal().getName(),
+            :subject      => tls_session.getPeerPrincipal().getName(),
             :cipher_suite => tls_session.getCipherSuite()
           }
         else


### PR DESCRIPTION
This PR is a proposal for adding the feature described here https://github.com/logstash-plugins/logstash-input-beats/issues/83

Unfortunately I could not fully test it due to https://github.com/logstash-plugins/logstash-input-beats/issues/326