### PR TITLE
Fix sending of acks when sequence number of batch does not start with 1

### DIFF
--- a/src/main/java/org/logstash/beats/Batch.java
+++ b/src/main/java/org/logstash/beats/Batch.java
@@ -23,6 +23,11 @@ public interface Batch extends Iterable<Message>{
     void setBatchSize(int batchSize);
 
     /**
+     * Returns the highest sequence number of the batch.
+     * @return
+     */
+    int getHighestSequence();
+    /**
      * Current number of messages in the batch
      * @return int
      */

--- a/src/main/java/org/logstash/beats/BeatsHandler.java
+++ b/src/main/java/org/logstash/beats/BeatsHandler.java
@@ -95,7 +95,7 @@ public class BeatsHandler extends SimpleChannelInboundHandler<Batch> {
     }
 
     private boolean needAck(Message message) {
-        return message.getSequence() == message.getBatch().getBatchSize();
+        return message.getSequence() == message.getBatch().getHighestSequence();
     }
 
     private void ack(ChannelHandlerContext ctx, Message message) {

--- a/src/main/java/org/logstash/beats/V1Batch.java
+++ b/src/main/java/org/logstash/beats/V1Batch.java
@@ -13,6 +13,7 @@ public class V1Batch implements Batch{
     private int batchSize;
     private List<Message> messages = new ArrayList<>();
     private byte protocol = Protocol.VERSION_1;
+    private int highestSequence = -1;
 
     @Override
     public byte getProtocol() {
@@ -30,6 +31,9 @@ public class V1Batch implements Batch{
     void addMessage(Message message){
         message.setBatch(this);
         messages.add(message);
+        if (message.getSequence() > highestSequence){
+            highestSequence = message.getSequence();
+        }
     }
 
     @Override
@@ -55,6 +59,11 @@ public class V1Batch implements Batch{
     @Override
     public boolean isEmpty() {
         return 0 == messages.size();
+    }
+
+    @Override
+    public int getHighestSequence(){
+        return highestSequence;
     }
 
     @Override

--- a/src/main/java/org/logstash/beats/V2Batch.java
+++ b/src/main/java/org/logstash/beats/V2Batch.java
@@ -14,6 +14,7 @@ public class V2Batch implements Batch {
     private int read = 0;
     private static final int SIZE_OF_INT = 4;
     private int batchSize;
+    private int highestSequence = -1;
 
     public void setProtocol(byte protocol){
         if (protocol != Protocol.VERSION_2){
@@ -72,6 +73,11 @@ public class V2Batch implements Batch {
         return written == batchSize;
     }
 
+    @Override
+    public int getHighestSequence(){
+        return highestSequence;
+    }
+
     /**
      * Adds a message to the batch, which will be constructed into an actual {@link Message} lazily.
       * @param sequenceNumber sequence number of the message within the batch
@@ -86,6 +92,9 @@ public class V2Batch implements Batch {
         internalBuffer.writeInt(sequenceNumber);
         internalBuffer.writeInt(size);
         buffer.readBytes(internalBuffer, size);
+        if (sequenceNumber > highestSequence){
+            highestSequence = sequenceNumber;
+        }
     }
 
     @Override

--- a/src/test/java/org/logstash/beats/V1BatchTest.java
+++ b/src/test/java/org/logstash/beats/V1BatchTest.java
@@ -3,6 +3,7 @@ package org.logstash.beats;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.security.SecureRandom;
 import java.util.HashMap;
 
 import static org.junit.Assert.*;
@@ -42,6 +43,19 @@ public class V1BatchTest {
 
         for(int i = 1; i <= numberOfEvent; i++) {
             batch.addMessage(new Message(i, new HashMap()));
+        }
+
+        assertTrue(batch.isComplete());
+    }
+
+    @Test
+    public void testCompleteBatchWithSequenceNumbersNotStartingAtOne(){
+        int numberOfEvent = 2;
+        int startSequenceNumber = new SecureRandom().nextInt(10000);
+        batch.setBatchSize(numberOfEvent);
+
+        for(int i = 1; i <= numberOfEvent; i++) {
+            batch.addMessage(new Message(startSequenceNumber + i, new HashMap()));
         }
 
         assertTrue(batch.isComplete());

--- a/src/test/java/org/logstash/beats/V1BatchTest.java
+++ b/src/test/java/org/logstash/beats/V1BatchTest.java
@@ -61,6 +61,20 @@ public class V1BatchTest {
         assertTrue(batch.isComplete());
     }
 
+
+    @Test
+    public void testHighSequence(){
+        int numberOfEvent = 2;
+        int startSequenceNumber = new SecureRandom().nextInt(10000);
+        batch.setBatchSize(numberOfEvent);
+
+        for(int i = 1; i <= numberOfEvent; i++) {
+            batch.addMessage(new Message(startSequenceNumber + i, new HashMap()));
+        }
+
+        assertEquals(startSequenceNumber + numberOfEvent, batch.getHighestSequence());
+    }
+
     @Test
     public void TestCompleteReturnWhenTheNumberOfEventDoesntMatchBatchSize() {
         int numberOfEvent = 2;

--- a/src/test/java/org/logstash/beats/V2BatchTest.java
+++ b/src/test/java/org/logstash/beats/V2BatchTest.java
@@ -7,6 +7,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.junit.Test;
 
+import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -73,6 +74,21 @@ public class V2BatchTest {
         }finally {
             batch.release();
         }
+    }
+
+    @Test
+    public void testHighSequence(){
+        V2Batch batch = new V2Batch();
+        int numberOfEvent = 2;
+        int startSequenceNumber = new SecureRandom().nextInt(10000);
+        batch.setBatchSize(numberOfEvent);
+        ByteBuf content = messageContents();
+
+        for(int i = 1; i <= numberOfEvent; i++) {
+            batch.addMessage(startSequenceNumber + i, content, content.readableBytes());
+        }
+
+        assertEquals(startSequenceNumber + numberOfEvent, batch.getHighestSequence());
     }
 
 


### PR DESCRIPTION
Acknowledgements back to the sender were only being sent when the sequence
number of the message being handled was equal to the size of the batch.
This was causing a problem with the lumberjack output, as the underlying
jls-lumberjack library does not reset the sequence number to 1 for each
batch. This was causing a signficant slowdown in the lumberjack output to
beats input pipeline.