### PR TITLE
Improve consistency of messaging around `ssl_verify_mode`

### DIFF
--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -145,11 +145,11 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
     end
 
     if @ssl && require_certificate_authorities? && !client_authentification?
-      raise LogStash::ConfigurationError, "Using `verify_mode` set to PEER or FORCE_PEER, requires the configuration of `certificate_authorities`"
+      raise LogStash::ConfigurationError, "Using `ssl_verify_mode` set to `peer` or `force_peer`, requires the configuration of `certificate_authorities`"
     end
 
     if client_authentication_metadata? && !require_certificate_authorities?
-      raise LogStash::ConfigurationError, "Enabling `peer_metadata` requires using `verify_mode` set to PEER or FORCE_PEER"
+      raise LogStash::ConfigurationError, "Enabling `peer_metadata` requires using `ssl_verify_mode` set to `peer` or `force_peer`"
     end
 
     # Logstash 6.x breaking change (introduced with 4.0.0 of this gem)
@@ -217,7 +217,7 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
   end
 
   def client_authentication_required?
-    @ssl_verify_mode == "force_peer" 
+    @ssl_verify_mode == "force_peer"
   end
 
   def require_certificate_authorities?

--- a/spec/inputs/beats_spec.rb
+++ b/spec/inputs/beats_spec.rb
@@ -62,13 +62,22 @@ describe LogStash::Inputs::Beats do
         end
       end
 
-      context "verify_mode" do
-        context "verify_mode configured to PEER" do
+      context "ssl_verify_mode" do
+        context 'ssl_verify_mode requires downcased values' do
+          let(:config)   { {"ssl_certificate_authorities" => [certificate.ssl_cert], "port" => 0, "ssl" => true, "ssl_verify_mode" => "PEER", "ssl_certificate" => certificate.ssl_cert, "ssl_key" => certificate.ssl_key, "type" => "example", "tags" => "Beats"} }
+
+          it "raise a ConfigurationError when ssl_verify_mode is not downcased" do
+            expect {LogStash::Inputs::Beats.new(config)}.to raise_error(LogStash::ConfigurationError)
+          end
+
+        end
+
+        context "ssl_verify_mode configured to peer" do
           let(:config)   { { "port" => 0, "ssl" => true, "ssl_verify_mode" => "peer", "ssl_certificate" => certificate.ssl_cert, "ssl_key" => certificate.ssl_key, "type" => "example", "tags" => "Beats"} }
 
           it "raise a ConfigurationError when certificate_authorities is not set" do
             plugin = LogStash::Inputs::Beats.new(config)
-            expect {plugin.register}.to raise_error(LogStash::ConfigurationError, "Using `verify_mode` set to PEER or FORCE_PEER, requires the configuration of `certificate_authorities`")
+            expect {plugin.register}.to raise_error(LogStash::ConfigurationError, "Using `ssl_verify_mode` set to `peer` or `force_peer`, requires the configuration of `certificate_authorities`")
           end
 
           it "doesn't raise a configuration error when certificate_authorities is set" do
@@ -78,12 +87,12 @@ describe LogStash::Inputs::Beats do
           end
         end
 
-        context "verify_mode configured to FORCE_PEER" do
+        context "ssl_verify_mode configured to force_peer" do
           let(:config)   { { "port" => 0, "ssl" => true, "ssl_verify_mode" => "force_peer", "ssl_certificate" => certificate.ssl_cert, "ssl_key" => certificate.ssl_key, "type" => "example", "tags" => "Beats"} }
 
           it "raise a ConfigurationError when certificate_authorities is not set" do
             plugin = LogStash::Inputs::Beats.new(config)
-            expect {plugin.register}.to raise_error(LogStash::ConfigurationError, "Using `verify_mode` set to PEER or FORCE_PEER, requires the configuration of `certificate_authorities`")
+            expect {plugin.register}.to raise_error(LogStash::ConfigurationError, "Using `ssl_verify_mode` set to `peer` or `force_peer`, requires the configuration of `certificate_authorities`")
           end
 
           it "doesn't raise a configuration error when certificate_authorities is set" do


### PR DESCRIPTION
Ensure that log messages use the correct settings and values for `ssl_verify_mode`. Use downcased version of `force_peer` and `peer` in ruby code and logs consistently rather than mixing cases.