### PR TITLE
experimental introduction of a bounded queue and rejection handler

### DIFF
--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -162,7 +162,7 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
   end # def register
 
   def create_server
-    server = org.logstash.beats.Server.new(@host, @port, @client_inactivity_timeout, @executor_threads)
+    server = org.logstash.beats.Server.new(@host, @port, @client_inactivity_timeout, @executor_threads, 5)
     if @ssl
       ssl_context_builder = new_ssl_context_builder
       if client_authentification?

--- a/spec/inputs/beats_spec.rb
+++ b/spec/inputs/beats_spec.rb
@@ -34,7 +34,7 @@ describe LogStash::Inputs::Beats do
       subject(:plugin) { LogStash::Inputs::Beats.new(config) }
 
       it "sends the required options to the server" do
-        expect(org.logstash.beats.Server).to receive(:new).with(host, port, client_inactivity_timeout, threads)
+        expect(org.logstash.beats.Server).to receive(:new).with(host, port, client_inactivity_timeout, threads, 5)
         subject.register
       end
     end

--- a/src/main/java/org/logstash/beats/CustomRejectedExecutionHandler.java
+++ b/src/main/java/org/logstash/beats/CustomRejectedExecutionHandler.java
@@ -1,0 +1,18 @@
+package org.logstash.beats;
+
+import io.netty.util.concurrent.RejectedExecutionHandler;
+import io.netty.util.concurrent.SingleThreadEventExecutor;
+
+public class CustomRejectedExecutionHandler implements RejectedExecutionHandler {
+
+    @Override
+    public void rejected(Runnable task, SingleThreadEventExecutor executor) {
+        System.out.println("Requeueing the message");
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        executor.execute(task);
+    }
+}

--- a/src/main/java/org/logstash/beats/DaemonThreadFactory.java
+++ b/src/main/java/org/logstash/beats/DaemonThreadFactory.java
@@ -1,0 +1,30 @@
+package org.logstash.beats;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class DaemonThreadFactory implements ThreadFactory {
+
+    final ThreadGroup group;
+    final AtomicInteger threadNumber = new AtomicInteger(1);
+    final String namePrefix;
+
+    DaemonThreadFactory(String namePrefix) {
+        this.namePrefix = namePrefix;
+        group = Thread.currentThread().getThreadGroup();
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+        Thread t = new Thread(group, r,
+                namePrefix + "[T#" + threadNumber.getAndIncrement() + "]",
+                0);
+        t.setDaemon(true);
+        return t;
+    }
+
+    public static ThreadFactory daemonThreadFactory(String namePrefix) {
+        return new DaemonThreadFactory(namePrefix);
+    }
+
+}

--- a/src/main/java/org/logstash/beats/Runner.java
+++ b/src/main/java/org/logstash/beats/Runner.java
@@ -20,7 +20,7 @@ public class Runner {
         // Check for leaks.
         // ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.PARANOID);
 
-        Server server = new Server("0.0.0.0", DEFAULT_PORT, 15, Runtime.getRuntime().availableProcessors());
+        Server server = new Server("0.0.0.0", DEFAULT_PORT, 15, Runtime.getRuntime().availableProcessors(), 128);
 
             if(args.length > 0 && args[0].equals("ssl")) {
             logger.debug("Using SSL");

--- a/src/main/java/org/logstash/beats/Server.java
+++ b/src/main/java/org/logstash/beats/Server.java
@@ -115,12 +115,12 @@ public class Server {
         private final IMessageListener localMessageListener;
         private final int localClientInactivityTimeoutSeconds;
 
-        BeatsInitializer(IMessageListener messageListener, int clientInactivityTimeoutSeconds, int beatsHandlerThread, int maxPendingRequests) {
+        BeatsInitializer(IMessageListener messageListener, int clientInactivityTimeoutSeconds, int beatsHandlerThreadCount, int maxPendingRequests) {
             // Keeps a local copy of Server settings, so they can't be modified once it starts listening
             this.localMessageListener = messageListener;
             this.localClientInactivityTimeoutSeconds = clientInactivityTimeoutSeconds;
             idleExecutorGroup = new DefaultEventExecutorGroup(DEFAULT_IDLESTATEHANDLER_THREAD);
-            beatsHandlerExecutorGroup = new DefaultEventExecutorGroup(beatsHandlerThread, daemonThreadFactory("beats-input-handler-executor"), maxPendingRequests, new CustomRejectedExecutionHandler());
+            beatsHandlerExecutorGroup = new DefaultEventExecutorGroup(beatsHandlerThreadCount, daemonThreadFactory("beats-input-handler-executor"), maxPendingRequests, new CustomRejectedExecutionHandler());
             //beatsHandlerExecutorGroup = new DefaultEventExecutorGroup(beatsHandlerThread);
         }
 

--- a/src/test/java/org/logstash/beats/ServerTest.java
+++ b/src/test/java/org/logstash/beats/ServerTest.java
@@ -34,6 +34,7 @@ public class ServerTest {
     private EventLoopGroup group;
     private final String host = "0.0.0.0";
     private final int threadCount = 10;
+    private final int maxPendingRequests = 128;
 
     @Before
     public void setUp() {
@@ -50,7 +51,7 @@ public class ServerTest {
 
         final CountDownLatch latch = new CountDownLatch(concurrentConnections);
 
-        final Server server = new Server(host, randomPort, inactivityTime, threadCount);
+        final Server server = new Server(host, randomPort, inactivityTime, threadCount, maxPendingRequests);
         final AtomicBoolean otherCause = new AtomicBoolean(false);
         server.setMessageListener(new MessageListener() {
             public void onNewConnection(ChannelHandlerContext ctx) {
@@ -114,7 +115,7 @@ public class ServerTest {
 
         final CountDownLatch latch = new CountDownLatch(concurrentConnections);
         final AtomicBoolean exceptionClose = new AtomicBoolean(false);
-        final Server server = new Server(host, randomPort, inactivityTime, threadCount);
+        final Server server = new Server(host, randomPort, inactivityTime, threadCount, maxPendingRequests);
         server.setMessageListener(new MessageListener() {
             @Override
             public void onNewConnection(ChannelHandlerContext ctx) {
@@ -170,7 +171,7 @@ public class ServerTest {
 
     @Test
     public void testServerShouldAcceptConcurrentConnection() throws InterruptedException {
-        final Server server = new Server(host, randomPort, 30, threadCount);
+        final Server server = new Server(host, randomPort, 30, threadCount, maxPendingRequests);
         SpyListener listener = new SpyListener();
         server.setMessageListener(listener);
         Runnable serverTask = new Runnable() {


### PR DESCRIPTION
Currently the beats input will accept connections and pass the work of decoding the message to an executor that has an unbouded queue.

This makes it so that the number of batches in flight in Logstash's off heap memory will equal the number of beats (more if pipelining is enabled).

To avoid this, this draft PR introduced a bounded queue for the executor where, after the queue is full, the netty group executor's threads will continuously try to submit the message for processing until there is room in the queue.