### PR TITLE
Downgrade netty due to IdleStateHandler issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     testCompile 'org.hamcrest:hamcrest-library:1.3'
     testCompile 'org.apache.logging.log4j:log4j-core:2.11.1'
 
-    compile 'io.netty:netty-all:4.1.44.Final'
+    compile 'io.netty:netty-all:4.1.34.Final'
     compile 'io.netty:netty-tcnative-boringssl-static:2.0.28.Final'
     compile 'org.javassist:javassist:3.24.0-GA'
     compile "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"


### PR DESCRIPTION
It appears sending lumberjack payloads to a beats input running netty 4.1.35 or newer causes the acknowledge to take a long time to be written back to the client, often causing i/o timeouts. 

One can find more information in https://github.com/netty/netty/issues/8912 and https://github.com/elastic/logstash/issues/11517.

While further investigation is done, this PR downgrades netty to .34