### PR TITLE
Doc: Add input-agent doc file

### DIFF
--- a/docs/agent.asciidoc
+++ b/docs/agent.asciidoc
@@ -1,0 +1,313 @@
+:plugin: beats
+:type: input
+:default_codec: plain
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: %VERSION%
+:release_date: %RELEASE_DATE%
+:changelog_url: %CHANGELOG_URL%
+:include_path: ../../../../logstash/docs/include
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="plugins-{type}s-{plugin}"]
+
+=== Beats input plugin
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+This input plugin enables Logstash to receive events from the
+https://www.elastic.co/products/beats[Elastic Beats] framework.
+
+The following example shows how to configure Logstash to listen on port
+5044 for incoming Beats connections and to index into Elasticsearch.
+
+[source,logstash]
+-----
+
+input {
+  beats {
+    port => 5044
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => ["http://localhost:9200"]
+    index => "%{[@metadata][beat]}-%{[@metadata][version]}" <1>
+  }
+}
+-----
+<1> `%{[@metadata][beat]}` sets the first part of the index name to the value
+of the `beat` metadata field and `%{[@metadata][version]}` sets the second part to
+the Beat's version. For example:
+metricbeat-7.4.0.
+
+Events indexed into Elasticsearch with the Logstash configuration shown here
+will be similar to events directly indexed by Beats into Elasticsearch.
+
+NOTE: If ILM is not being used, set `index` to
+`%{[@metadata][beat]}-%{[@metadata][version]}-%{+YYYY.MM.dd}` instead so
+Logstash creates an index per day, based on the `@timestamp` value of the events
+coming from Beats.
+
+IMPORTANT: If you are shipping events that span multiple lines, you need to use
+the {filebeat-ref}/multiline-examples.html[configuration options available in
+Filebeat] to handle multiline events before sending the event data to Logstash.
+You cannot use the {logstash-ref}/plugins-codecs-multiline.html[Multiline codec
+plugin] to handle multiline events. Doing so will result in the failure to start
+Logstash.
+
+[id="plugins-{type}s-{plugin}-versioned-indexes"]
+==== Versioned Beats Indices
+
+To minimize the impact of future schema changes on your existing indices and
+mappings in Elasticsearch, configure the Elasticsearch output to write to
+versioned indices. The pattern that you specify for the `index` setting
+controls the index name:
+
+[source,yaml]
+----
+index => "%{[@metadata][beat]}-%{[@metadata][version]}-%{+YYYY.MM.dd}"
+----
+
+`%{[@metadata][beat]}`:: Sets the first part of the index name to the value of
+the `beat` metadata field, for example, `filebeat`.
+`%{[@metadata][version]}`:: Sets the second part of the name to the Beat
+version, for example, +{logstash_version}+.
+`%{+YYYY.MM.dd}`:: Sets the third part of the name to a date based on the
+Logstash `@timestamp` field.
+
+This configuration results in daily index names like
++filebeat-{logstash_version}-{localdate}+.
+
+
+[id="plugins-{type}s-{plugin}-ecs_metadata"]
+==== Event Metadata and the Elastic Common Schema (ECS)
+When decoding `beats` events, this plugin adds two fields related to the event: the deprecated `host`
+which contains the `hostname` provided by beats and the `ip_address` containing the remote address
+of the client's connection. When <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>> is
+enabled these are now moved in ECS compatible namespace.
+
+[id="plugins-{type}s-{plugin}-options"]
+==== Beats Input Configuration Options
+
+This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-add_hostname>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-cipher_suites>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-client_inactivity_timeout>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> | <<string,string>>|No
+| <<plugins-{type}s-{plugin}-host>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-include_codec_tag>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-port>> |<<number,number>>|Yes
+| <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-ssl_certificate>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-ssl_certificate_authorities>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-ssl_handshake_timeout>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-ssl_key>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-ssl_key_passphrase>> |<<password,password>>|No
+| <<plugins-{type}s-{plugin}-ssl_verify_mode>> |<<string,string>>, one of `["none", "peer", "force_peer"]`|No
+| <<plugins-{type}s-{plugin}-ssl_peer_metadata>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-tls_max_version>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-tls_min_version>> |<<number,number>>|No
+|=======================================================================
+
+Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
+input plugins.
+
+&nbsp;
+
+[id="plugins-{type}s-{plugin}-add_hostname"]
+===== `add_hostname`
+
+  deprecated[6.0.0, The default value has been changed to `false`. In 7.0.0 this setting will be removed]
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Flag to determine whether to add `host` field to event using the value supplied by the beat in the `hostname` field.
+
+
+[id="plugins-{type}s-{plugin}-cipher_suites"]
+===== `cipher_suites`
+
+  * Value type is <<array,array>>
+  * Default value is `java.lang.String[TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256]@459cfcca`
+
+The list of ciphers suite to use, listed by priorities.
+
+[id="plugins-{type}s-{plugin}-client_inactivity_timeout"]
+===== `client_inactivity_timeout`
+
+  * Value type is <<number,number>>
+  * Default value is `60`
+
+Close Idle clients after X seconds of inactivity.
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+* Value type is <<string,string>>
+* Supported values are:
+** `disabled`: unstructured connection metadata added at root level
+** `v1`: structured connection metadata added under ECS compliant namespaces
+* Default value depends on which version of Logstash is running:
+** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+** Otherwise, the default value is `disabled`.
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
+The value of this setting affects the keys for the Beats connection's metadata on the event:
+
+.Metadata Location by `ecs_compatibility` value
+[cols="<l,<l,e,<e"]
+|=======================================================================
+|`disabled`              |`v1`                      |Availability |Description
+
+|[host]                  |[@metadata][input][beats][host][name]   |Always       |Name or address of the beat host
+|[@metadata][ip_address] |[@metadata][input][beats][host][ip]     |Always       |IP address of the Beats client
+|[@metadata][tls_peer][status] | [@metadata][tls_peer][status] | When SSL related fields are populated | Contains "verified"/"unverified" labels in `disabled`, `true`/`false` in `v1`
+|[@metadata][tls_peer][protocol] | [@metadata][input][beats][tls][version_protocol] | When SSL status is "verified" | Contains the TLS version used (e.g. `TLSv1.2`)
+|[@metadata][tls_peer][subject] | [@metadata][input][beats][tls][client][subject] | When SSL status is "verified" | Contains the identity name of the remote end (e.g. `CN=artifacts-no-kpi.elastic.co`)
+|[@metadata][tls_peer][cipher_suite] | [@metadata][input][beats][tls][cipher] | When SSL status is "verified" | Contains the name of cipher suite used (e.g. `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`)
+|=======================================================================
+
+[id="plugins-{type}s-{plugin}-host"]
+===== `host`
+
+  * Value type is <<string,string>>
+  * Default value is `"0.0.0.0"`
+
+The IP address to listen on.
+
+[id="plugins-{type}s-{plugin}-include_codec_tag"]
+===== `include_codec_tag`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `true`
+
+
+
+[id="plugins-{type}s-{plugin}-port"]
+===== `port`
+
+  * This is a required setting.
+  * Value type is <<number,number>>
+  * There is no default value for this setting.
+
+The port to listen on.
+
+[id="plugins-{type}s-{plugin}-ssl"]
+===== `ssl`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Events are by default sent in plain text. You can
+enable encryption by setting `ssl` to true and configuring
+the `ssl_certificate` and `ssl_key` options.
+
+[id="plugins-{type}s-{plugin}-ssl_certificate"]
+===== `ssl_certificate`
+
+  * Value type is <<path,path>>
+  * There is no default value for this setting.
+
+SSL certificate to use.
+
+[id="plugins-{type}s-{plugin}-ssl_certificate_authorities"]
+===== `ssl_certificate_authorities`
+
+  * Value type is <<array,array>>
+  * Default value is `[]`
+
+Validate client certificates against these authorities.
+You can define multiple files or paths. All the certificates will
+be read and added to the trust store. You need to configure the `ssl_verify_mode`
+to `peer` or `force_peer` to enable the verification.
+
+
+[id="plugins-{type}s-{plugin}-ssl_handshake_timeout"]
+===== `ssl_handshake_timeout`
+
+  * Value type is <<number,number>>
+  * Default value is `10000`
+
+Time in milliseconds for an incomplete ssl handshake to timeout
+
+[id="plugins-{type}s-{plugin}-ssl_key"]
+===== `ssl_key`
+
+  * Value type is <<path,path>>
+  * There is no default value for this setting.
+
+SSL key to use.
+NOTE: This key need to be in the PKCS8 format, you can convert it with https://www.openssl.org/docs/man1.1.0/apps/pkcs8.html[OpenSSL]
+for more information.
+
+[id="plugins-{type}s-{plugin}-ssl_key_passphrase"]
+===== `ssl_key_passphrase`
+
+  * Value type is <<password,password>>
+  * There is no default value for this setting.
+
+SSL key passphrase to use.
+
+[id="plugins-{type}s-{plugin}-ssl_verify_mode"]
+===== `ssl_verify_mode`
+
+  * Value can be any of: `none`, `peer`, `force_peer`
+  * Default value is `"none"`
+
+By default the server doesn't do any client verification.
+
+`peer` will make the server ask the client to provide a certificate.
+If the client provides a certificate, it will be validated.
+
+`force_peer` will make the server ask the client to provide a certificate.
+If the client doesn't provide a certificate, the connection will be closed.
+
+This option needs to be used with `ssl_certificate_authorities` and a defined list of CAs.
+
+[id="plugins-{type}s-{plugin}-ssl_peer_metadata"]
+===== `ssl_peer_metadata`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Enables storing client certificate information in event's metadata.
+
+This option is only valid when `ssl_verify_mode` is set to `peer` or `force_peer`.
+
+[id="plugins-{type}s-{plugin}-tls_max_version"]
+===== `tls_max_version`
+
+  * Value type is <<number,number>>
+  * Default value is `1.2`
+
+The maximum TLS version allowed for the encrypted connections. The value must be the one of the following:
+1.0 for TLS 1.0, 1.1 for TLS 1.1, 1.2 for TLS 1.2
+
+[id="plugins-{type}s-{plugin}-tls_min_version"]
+===== `tls_min_version`
+
+  * Value type is <<number,number>>
+  * Default value is `1`
+
+The minimum TLS version allowed for the encrypted connections. The value must be one of the following:
+1.0 for TLS 1.0, 1.1 for TLS 1.1, 1.2 for TLS 1.2
+
+
+
+[id="plugins-{type}s-{plugin}-common-options"]
+include::{include_path}/{type}.asciidoc[]
+
+:default_codec!:

--- a/docs/agent.asciidoc
+++ b/docs/agent.asciidoc
@@ -1,21 +1,28 @@
-:plugin: beats
+:plugin: agent
 :type: input
 :default_codec: plain
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
+
+// Copied from Beats generated plugin output.
+// Not actively generated at this time!
+
+////
 :version: %VERSION%
 :release_date: %RELEASE_DATE%
 :changelog_url: %CHANGELOG_URL%
 :include_path: ../../../../logstash/docs/include
+////
+
 ///////////////////////////////////////////
 END - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////
 
 [id="plugins-{type}s-{plugin}"]
 
-=== Beats input plugin
+=== Agent input plugin
 
 include::{include_path}/plugin_header.asciidoc[]
 
@@ -95,7 +102,7 @@ of the client's connection. When <<plugins-{type}s-{plugin}-ecs_compatibility,EC
 enabled these are now moved in ECS compatible namespace.
 
 [id="plugins-{type}s-{plugin}-options"]
-==== Beats Input Configuration Options
+==== Agent Input Configuration Options
 
 This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
 


### PR DESCRIPTION
Add source file for input-agent docs to live beside beats source file
Start changing instances of "beats" to "agent" where appropriate. (Note: I can't do a complete search/replace at this time because some link targets don't exist. 

@andsel I'm adding this file so that we can both contribute to it.  This step will enable me to set up the needed framework for creating and publishing docs for Agent. 
