### PR TITLE
Doc: Add variable to code sample

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -18,6 +18,9 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === {plugin-uc} input plugin
 
+NOTE: The `input-elastic_agent` plugin is the next generation of the
+`input-beats` plugin. They currently share a common codebase.
+
 include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
@@ -46,7 +49,7 @@ output {
 -----
 <1> `%{[@metadata][beat]}` sets the first part of the index name to the value
 of the `beat` metadata field and `%{[@metadata][version]}` sets the second part to
-the {plugin-uc}'s version. For example:
+the {plugin-uc} version. For example:
 metricbeat-7.4.0.
 
 Events indexed into Elasticsearch with the Logstash configuration shown here

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -32,7 +32,7 @@ The following example shows how to configure Logstash to listen on port
 -----
 
 input {
-  beats {
+  {plugin} {
     port => 5044
   }
 }


### PR DESCRIPTION
In #415 we implemented attributes and set up code samples to accommodate attributes, but didn't actually implement the attribute in the code sample. This PR switches out the hard coded value in the code sample with an attribute. 

**ToDo:**
*  Look through source file to be sure we didn't miss any other instances of hard coded plugin name. 
*  Line 49 "<1> `%{[@metadata][beat]}` sets the first part of the index name to the value
of the `beat` metadata field" . Figure out best implementation for `beat` (singular).
* Determine messaging and location for relationship of origin/destination of aliased plugins. (See an idea in comments below.) 

**Note:**
* An across the board search-replace won't work. We have to be selective to avoid screwing up context and breaking links. 
