### PR TITLE
Updated Jackson dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+ - Updated Jackson dependencies
+
 ## 6.1.2
  - [DOC] Added naming attribute to control plugin name that appears in docs, and set up framework to make attributes viable in code sample
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 String jacksonVersion = '2.9.10'
-String jacksonDatabindVersion = '2.9.10.4'
+String jacksonDatabindVersion = '2.9.10.8'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
This change removes following CVEs reported by vulnerability scanners for logstash-input-beats due to jackson-databind-2.9.10.4

* https://nvd.nist.gov/vuln/detail/CVE-2020-14060
* https://nvd.nist.gov/vuln/detail/CVE-2020-14061
* https://nvd.nist.gov/vuln/detail/CVE-2020-14062
* https://nvd.nist.gov/vuln/detail/CVE-2020-14195
* https://nvd.nist.gov/vuln/detail/CVE-2020-24616
* https://nvd.nist.gov/vuln/detail/CVE-2020-24750
* https://nvd.nist.gov/vuln/detail/CVE-2020-25649
* https://nvd.nist.gov/vuln/detail/CVE-2020-35490
* https://nvd.nist.gov/vuln/detail/CVE-2020-35491
* https://nvd.nist.gov/vuln/detail/CVE-2020-35728
* https://nvd.nist.gov/vuln/detail/CVE-2020-36179
* https://nvd.nist.gov/vuln/detail/CVE-2020-36180
* https://nvd.nist.gov/vuln/detail/CVE-2020-36181
* https://nvd.nist.gov/vuln/detail/CVE-2020-36182
* https://nvd.nist.gov/vuln/detail/CVE-2020-36183
* https://nvd.nist.gov/vuln/detail/CVE-2020-36184
* https://nvd.nist.gov/vuln/detail/CVE-2020-36185
* https://nvd.nist.gov/vuln/detail/CVE-2020-36186
* https://nvd.nist.gov/vuln/detail/CVE-2020-36187
* https://nvd.nist.gov/vuln/detail/CVE-2020-36188
* https://nvd.nist.gov/vuln/detail/CVE-2020-36189
* https://nvd.nist.gov/vuln/detail/CVE-2021-20190

