### PR TITLE
Disable ECS compatibility of plain codec with elastic_agent

### DIFF
--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -196,7 +196,7 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
 
     # Prevent ingest pipelines having an issue when using ECS compatibility where replaces message to event.original field
     # GH issue: https://github.com/logstash-plugins/logstash-input-elastic_agent/issues/3
-    if @codec.class.eql?(LogStash::Codecs::Plain)
+    if @codec.class.eql?(LogStash::Codecs::Plain) && !@codec.ecs_compatibility.eql?(:disabled)
       @codec = LogStash::Codecs::Plain.new('charset' => @codec.charset, 'format' => @codec.format, 'ecs_compatibility' => 'disabled')
     end
 

--- a/lib/logstash/inputs/beats.rb
+++ b/lib/logstash/inputs/beats.rb
@@ -194,6 +194,12 @@ class LogStash::Inputs::Beats < LogStash::Inputs::Base
       configuration_error "Multiline codec with beats input is not supported. Please refer to the beats documentation for how to best manage multiline data. See https://www.elastic.co/guide/en/beats/filebeat/current/multiline-examples.html"
     end
 
+    # Prevent ingest pipelines having an issue when using ECS compatibility where replaces message to event.original field
+    # GH issue: https://github.com/logstash-plugins/logstash-input-elastic_agent/issues/3
+    if @codec.class.eql?(LogStash::Codecs::Plain)
+      @codec = LogStash::Codecs::Plain.new('charset' => @codec.charset, 'format' => @codec.format, 'ecs_compatibility' => 'disabled')
+    end
+
     # define ecs name mapping
     @field_hostname = ecs_select[disabled: "host", v1: "[@metadata][input][beats][host][name]"]
     @field_hostip = ecs_select[disabled: "[@metadata][ip_address]", v1: "[@metadata][input][beats][host][ip]"]

--- a/lib/logstash/inputs/beats/codec_callback_listener.rb
+++ b/lib/logstash/inputs/beats/codec_callback_listener.rb
@@ -2,12 +2,12 @@
 require "logstash/inputs/beats"
 
 module LogStash module Inputs class Beats
-  # Use the new callback based approch instead of using blocks
+  # Use the new callback based approach instead of using blocks
   # so we can retain some context of the execution, and make it easier to test
   class CodecCallbackListener
     attr_accessor :data
     # The path acts as the `stream_identity`, 
-    # usefull when the clients is reading multiples files
+    # useful when the clients is reading multiples files
     attr_accessor :path
 
     def initialize(data, hash, path, transformer, queue)

--- a/spec/inputs/beats_spec.rb
+++ b/spec/inputs/beats_spec.rb
@@ -200,6 +200,14 @@ describe LogStash::Inputs::Beats do
         expect { plugin.register }.to raise_error(LogStash::ConfigurationError, "Multiline codec with beats input is not supported. Please refer to the beats documentation for how to best manage multiline data. See https://www.elastic.co/guide/en/beats/filebeat/current/multiline-examples.html")
       end
     end
+
+    context "with default plain codec" do
+      it "disables the ECS compatibility" do
+        plugin = LogStash::Inputs::Beats.new(config)
+        expect { plugin.register }.not_to raise_error
+        expect( plugin.codec.ecs_compatibility ).to eql :disabled
+      end
+    end
   end
 
   context "tls meta-data" do

--- a/src/main/java/org/logstash/beats/Server.java
+++ b/src/main/java/org/logstash/beats/Server.java
@@ -72,7 +72,7 @@ public class Server {
         logger.debug("Server stopped");
     }
 
-    private void shutdown(){
+    private void shutdown() {
         try {
             if (workGroup != null) {
                 workGroup.shutdownGracefully().sync();


### PR DESCRIPTION

We have been observing an issue with Ingest pipelines in the case where LS consumes data from elastic agent (data stream) and sends to ES. Logstash renames the `message` field to `event.original` and when ingest nodes index data into ES, `event.original` field already existed error is occurred.  The root cause is, `elastic_agent` plugin utilizes plain codec and the codec enables automatically the ECS where the `message` field replacement happens.

This PR disables the plain codec ECS when using with agents in order to keep the consistent data.

TODO if current approach is reasonable: 
 - link the issues
 - update the docs