### PR TITLE
fix jruby bundler for test

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -5,7 +5,7 @@ env
 
 set -ex
 
-jruby -rbundler/setup -S rspec -fd
+bundle exec rspec --format=documentation
 
-jruby -rbundler/setup -S rake test:integration:setup
-jruby -rbundler/setup -S rspec spec --tag integration  -fd
+bundle exec rake test:integration:setup
+bundle exec rspec spec --tag integration --format=documentation


### PR DESCRIPTION
Fix: https://github.com/elastic/logstash/issues/14800

Use the bundler in /vendor/bundle/jruby/2.6.0/bin/bundle instead of /vendor/jruby/bin/bundle to run test, as Logstash doesn't package the latter in artifacts in https://github.com/elastic/logstash/pull/14667

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
