### PR TITLE
Fix doc formatting regression

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -243,7 +243,7 @@ Refer to <<plugins-{type}s-{plugin}-ecs_metadata,ECS mapping>> for detailed info
 ===== `executor_threads`
 
   * Value type is <<number,number>>
-Default value is equal to the number of CPU cores (1 executor thread per CPU core).
+  * Default value is equal to the number of CPU cores (1 executor thread per CPU core).
 
 The number of threads to be used to process incoming beats requests.
 By default, the Beats Input creates a number of threads equal to the number of CPU cores.


### PR DESCRIPTION
Corrected formatting to resolve this formatting regression: 
<img width="821" alt="Screen Shot 2023-01-13 at 3 30 37 PM" src="https://user-images.githubusercontent.com/35154725/212413550-a41c7e90-47e3-40a0-9bf5-06a4f180f39d.png">

