### PR TITLE
Apply attribute to reinstate single sourcing

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -245,8 +245,8 @@ Refer to <<plugins-{type}s-{plugin}-ecs_metadata,ECS mapping>> for detailed info
   * Value type is <<number,number>>
   * Default value is equal to the number of CPU cores (1 executor thread per CPU core).
 
-The number of threads to be used to process incoming beats requests.
-By default, the Beats Input creates a number of threads equal to the number of CPU cores.
+The number of threads to be used to process incoming {plugin-uc} requests.
+By default, the {plugin-uc} input creates a number of threads equal to the number of CPU cores.
 These threads handle incoming connections, reading from established sockets, and executing most of the tasks related to network connection management. 
 Parsing the Lumberjack protocol is offloaded to a dedicated thread pool.
 


### PR DESCRIPTION
Remove hard-coded instances of plugin name to get single-sourcing (for Elastic Agent) working again, and fixes plugin capitalization
