### PR TITLE
Avoid to use RC2-128 cipher algorithm because starting from openssl3 has been moved in legacy provider

### DIFF
--- a/spec/integration/filebeat_spec.rb
+++ b/spec/integration/filebeat_spec.rb
@@ -222,6 +222,8 @@ describe "Filebeat", :integration => true do
 
             # NOTE: CentOS 7 base image (LS < 7.17) uses OpenSSL 1.0 while later is using Ubuntu 20.04 with OpenSSL 1.1.1
             # the default algorithm for `openssl pkcs8 -topk8` changed to -v2 which Java does not support (see GH-443)
+            # Strating from OpenSSL 3 RC ciphers algorithms has been moved into provider-legacy package which is not always awailable in all distros.
+            # Use cipher that is available in openssl main package.
             cmd = "openssl pkcs8 -topk8 -in #{cert_key} -out #{@cert_key_pkcs8} -v1 PBE-SHA1-3DES -passin pass:#{@passphrase} -passout pass:#{@passphrase}"
             unless system(cmd)
               fail "failed to run openssl command: #{$?} \n#{cmd}"

--- a/spec/integration/filebeat_spec.rb
+++ b/spec/integration/filebeat_spec.rb
@@ -222,7 +222,7 @@ describe "Filebeat", :integration => true do
 
             # NOTE: CentOS 7 base image (LS < 7.17) uses OpenSSL 1.0 while later is using Ubuntu 20.04 with OpenSSL 1.1.1
             # the default algorithm for `openssl pkcs8 -topk8` changed to -v2 which Java does not support (see GH-443)
-            cmd = "openssl pkcs8 -topk8 -in #{cert_key} -out #{@cert_key_pkcs8} -v1 PBE-SHA1-RC2-128 -passin pass:#{@passphrase} -passout pass:#{@passphrase}"
+            cmd = "openssl pkcs8 -topk8 -in #{cert_key} -out #{@cert_key_pkcs8} -v1 PBE-SHA1-3DES -passin pass:#{@passphrase} -passout pass:#{@passphrase}"
             unless system(cmd)
               fail "failed to run openssl command: #{$?} \n#{cmd}"
             end

--- a/spec/integration/filebeat_spec.rb
+++ b/spec/integration/filebeat_spec.rb
@@ -222,7 +222,7 @@ describe "Filebeat", :integration => true do
 
             # NOTE: CentOS 7 base image (LS < 7.17) uses OpenSSL 1.0 while later is using Ubuntu 20.04 with OpenSSL 1.1.1
             # the default algorithm for `openssl pkcs8 -topk8` changed to -v2 which Java does not support (see GH-443)
-            # Strating from OpenSSL 3 RC ciphers algorithms has been moved into provider-legacy package which is not always awailable in all distros.
+            # Starting from OpenSSL 3, RC cipher algorithms has been moved into provider-legacy package which is not always installed in all OSes.
             # Use cipher that is available in openssl main package.
             cmd = "openssl pkcs8 -topk8 -in #{cert_key} -out #{@cert_key_pkcs8} -v1 PBE-SHA1-3DES -passin pass:#{@passphrase} -passout pass:#{@passphrase}"
             unless system(cmd)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Avoid to use a cipher available in open ssl provider-legacy.
Starting from version 3 of OpenSSL `RC2` family of cipher was moved in another package, which is marked for deprecation: 
https://www.openssl.org/docs/man3.0/man7/EVP_CIPHER-RC2.html

This PR updates the cipher used in some openssl interaction inside integration tests.

## Why is it important/What is the impact to the user?

The developer that runs integration tests outside Docker, directly on his host with commands:
```sh
bundle install
bundle exec rake test:integration:setup
bundle exec rspec spec --tag integration --format=documentation -e "Filebeat TLS Server verification self signed certificate with a passphrase successfully send the events"
```
would suffer of a failure due to openssl command invocation.
This can also be verified on a command shell on the host with:
```sh
$> openssl req -x509  -batch -newkey rsa:2048 -keyout certificate.key -out certificate.crt -passout pass:foobar -subj "/C=EU/O=Logstash/CN=localhost"
$> openssl pkcs8 -topk8 -in certificate.key -out certificate.key.pkcs8 -v1 PBE-SHA1-RC2-128 -passin pass:foobar -passout pass:foobar
```

switching algorithm
```sh
$>openssl pkcs8 -topk8 -in certificate.key -out certificate.key.pkcs8 -v1 PBE-SHA1-3DES -passin pass:foobar -passout pass:foobar
```
it successed.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

On a host with installed openssl3 without `rc-` class of ciphers, runs the integration tests:
```sh
bundle install
bundle exec rake test:integration:setup
bundle exec rspec spec --tag integration --format=documentation
```

To verify the list of installed ciphers:
```sh
openssl -h
```
Check in the section `Ciphers commands` there isn't any `rc2-128`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #483 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

```
      self signed certificate
        with a passphrase
...+.+...+...........+....+.....+...+....+.....+......+.......+........+....+......+..+.+...........+....+++++++++++++++++++++++++++++++++++++++*....+....+.....+...+.......+....................+.........+.......+...+...........+.+..+++++++++++++++++++++++++++++++++++++++*........+.....+.+.....+.......+..+....+......+.........+..+............+.+.....+.+...............+........+...+....+...+..+...+................+..+............+.+..+.............+.....+.......+..............................+..+............+...+...+....+.....+.+............+...+.....+............+................+......+...+..........................+....+...........+.+...+..+.........+......+.+..+...+....+...+........+.......+........+...+.........+.............+........+.+...........+.......+...+.....+.............+......+...+......+..+.......+...+........+.........+......+.+.....+....+..+.......+..+...+...+....+...+.................+....+..+..................+.......+........+......+.+..+................+..+.......+...+..+............+.........+....+...+..+...+.............+......+......+........+.+.....+.........+......+...+.......+......+............+...+..............+....+......+.....+.........+.+...........+..........+........+.+......+..+.......+.....+..........+..................+..+.....................+....+..............+.+...+...........+.........+...+.......+........+.......+..+.+...+............+..+.......+........+......+.........+.......+......+...+.....+.+.....+...+.+.........+........+....+...+.....................+..+....+...+......+.........+......+..+.......+......+.....+.......+..+.+...........+.+..+...+...+.+......+.................+.......+...+..+...+...+...+....+......+.....+.+......+..+...........................+.+.....+.........+......+.......+......+.........++++++
....+.+..+++++++++++++++++++++++++++++++++++++++*.....+.......+..............+.+..+......+.+....................+...+.+..+.......+..+++++++++++++++++++++++++++++++++++++++*...+............+.+.....++++++
-----
Error encrypting key
80A0BFFB01000000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:crypto/evp/evp_fetch.c:341:Global default library context, Algorithm (RC2-CBC : 50), Properties ()
80A0BFFB01000000:error:11800067:PKCS12 routines:PKCS12_item_i2d_encrypt_ex:encrypt error:crypto/pkcs12/p12_decr.c:193:
80A0BFFB01000000:error:11800067:PKCS12 routines:PKCS8_set0_pbe_ex:encrypt error:crypto/pkcs12/p12_p8e.c:80:
          successfully send the events (FAILED - 1)

Failures:

  1) Filebeat TLS Server verification self signed certificate with a passphrase successfully send the events
     Failure/Error: fail "failed to run openssl command: #{$?} \n#{cmd}"

     RuntimeError:
       failed to run openssl command: pid 5691 exit 1
       openssl pkcs8 -topk8 -in /var/folders/f2/6ln9srr13hsdp3kwfz68w3940000gn/T/studtmp-c5b333338b8d46f47faf4f09e53d863dd1d42f169fd61aa5e2eee3ad9390/certificate.key -out /var/folders/f2/6ln9srr13hsdp3kwfz68w3940000gn/T/studtmp-c5b333338b8d46f47faf4f09e53d863dd1d42f169fd61aa5e2eee3ad9390/certificate.key.pkcs8 -v1 PBE-SHA1-RC2-128 -passin pass:foobar -passout pass:foobar
     Shared Example Group: "send events" called from ./spec/integration/filebeat_spec.rb:239
     # ./spec/integration/filebeat_spec.rb:229:in `block in <main>'

Finished in 0.14319 seconds (files took 1.8 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/integration/filebeat_spec.rb:207 # Filebeat TLS Server verification self signed certificate with a passphrase successfully send the events

Randomized with seed 28326
```