### PR TITLE
[WIP]read beats payload in javaheap chunked

### DIFF
--- a/src/main/java/org/logstash/beats/AckEncoder.java
+++ b/src/main/java/org/logstash/beats/AckEncoder.java
@@ -10,6 +10,11 @@ import io.netty.handler.codec.MessageToByteEncoder;
  *
  */
 public class AckEncoder extends MessageToByteEncoder<Ack> {
+
+    public AckEncoder() {
+        super(false);
+    }
+
     @Override
     protected void encode(ChannelHandlerContext ctx, Ack ack, ByteBuf out) throws Exception {
         out.writeByte(ack.getProtocol());

--- a/src/main/java/org/logstash/beats/BeatsHandler.java
+++ b/src/main/java/org/logstash/beats/BeatsHandler.java
@@ -1,5 +1,7 @@
 package org.logstash.beats;
 
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import org.apache.logging.log4j.LogManager;
@@ -93,7 +95,7 @@ public class BeatsHandler extends SimpleChannelInboundHandler<Batch> {
                 }
             } else {
                 final Throwable realCause = extractCause(cause, 0);
-                if (logger.isDebugEnabled()){
+                if (logger.isDebugEnabled()) {
                     logger.info(format("Handling exception: " + cause + " (caused by: " + realCause + ")"), cause);
                 } else {
                     logger.info(format("Handling exception: " + cause + " (caused by: " + realCause + ")"));

--- a/src/main/java/org/logstash/beats/V2Batch.java
+++ b/src/main/java/org/logstash/beats/V2Batch.java
@@ -80,7 +80,7 @@ public class V2Batch implements Batch {
 
     /**
      * Adds a message to the batch, which will be constructed into an actual {@link Message} lazily.
-      * @param sequenceNumber sequence number of the message within the batch
+     * @param sequenceNumber sequence number of the message within the batch
      * @param buffer A ByteBuf pointing to serialized JSon
      * @param size size of the serialized Json
      */

--- a/src/main/java/org/logstash/beats/V2Batch.java
+++ b/src/main/java/org/logstash/beats/V2Batch.java
@@ -9,15 +9,15 @@ import java.util.Iterator;
  * Implementation of {@link Batch} for the v2 protocol backed by ByteBuf. *must* be released after use.
  */
 public class V2Batch implements Batch {
-    private ByteBuf internalBuffer = PooledByteBufAllocator.DEFAULT.buffer();
+    private final ByteBuf internalBuffer = PooledByteBufAllocator.DEFAULT.heapBuffer();
     private int written = 0;
     private int read = 0;
     private static final int SIZE_OF_INT = 4;
     private int batchSize;
     private int highestSequence = -1;
 
-    public void setProtocol(byte protocol){
-        if (protocol != Protocol.VERSION_2){
+    public void setProtocol(byte protocol) {
+        if (protocol != Protocol.VERSION_2) {
             throw new IllegalArgumentException("Only version 2 protocol is supported");
         }
     }
@@ -27,7 +27,7 @@ public class V2Batch implements Batch {
         return Protocol.VERSION_2;
     }
 
-    public Iterator<Message> iterator(){
+    public Iterator<Message> iterator() {
         internalBuffer.resetReaderIndex();
         return new Iterator<Message>() {
             @Override
@@ -86,13 +86,13 @@ public class V2Batch implements Batch {
      */
     void addMessage(int sequenceNumber, ByteBuf buffer, int size) {
         written++;
-        if (internalBuffer.writableBytes() < size + (2 * SIZE_OF_INT)){
+        if (internalBuffer.writableBytes() < size + (2 * SIZE_OF_INT)) {
             internalBuffer.capacity(internalBuffer.capacity() + size + (2 * SIZE_OF_INT));
         }
         internalBuffer.writeInt(sequenceNumber);
         internalBuffer.writeInt(size);
         buffer.readBytes(internalBuffer, size);
-        if (sequenceNumber > highestSequence){
+        if (sequenceNumber > highestSequence) {
             highestSequence = sequenceNumber;
         }
     }

--- a/src/test/java/org/logstash/beats/BeatsParserTest.java
+++ b/src/test/java/org/logstash/beats/BeatsParserTest.java
@@ -39,7 +39,7 @@ public class BeatsParserTest {
         this.v1Batch = new V1Batch();
 
         for(int i = 1; i <= numberOfMessage; i++) {
-            Map map = new HashMap<String, String>();
+            Map<String, String> map = new HashMap<>();
             map.put("line", "Another world");
             map.put("from", "Little big Adventure");
 
@@ -50,7 +50,7 @@ public class BeatsParserTest {
         this.byteBufBatch = new V2Batch();
 
         for(int i = 1; i <= numberOfMessage; i++) {
-            Map map = new HashMap<String, String>();
+            Map<String, String> map = new HashMap<>();
             map.put("line", "Another world");
             map.put("from", "Little big Adventure");
             ByteBuf bytebuf = Unpooled.wrappedBuffer(MAPPER.writeValueAsBytes(map));


### PR DESCRIPTION
This is a draft PR to investigate if the decompression or the decoding of JSON payloads done in Netty heap pool arenas, could manifest any performance drop vs direct memory.