### PR TITLE
6.x Backport: Remove jar-dependencies dependency

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -3,5 +3,5 @@
 if [ $(command -v apt) ]; then
     sudo apt install -y openssl
 else
-    sudo yum install -y openssl
+    sudo microdnf install -y openssl
 fi

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -40,17 +40,19 @@ namespace :test do
         puts "Filebeat: downloading from #{FILEBEAT_URL} to #{download_destination}"
         download(FILEBEAT_URL, download_destination)
 
-        untar_all(download_destination, File.join(VENDOR_PATH, "filebeat")) { |e| e }
+        untar_all(download_destination, VENDOR_PATH) { |e| e }
       end
     end
   end
 end
 
-# Uncompress all the file from the archive this only work with 
-# one level directory structure and filebeat packaging.
+require 'zlib'
+require 'minitar'
+
 def untar_all(file, destination)
-  untar(file) do |entry| 
-    out = entry.full_name.split("/").last
-    File.join(destination, out)
+  Zlib::GzipReader.open(file) do |reader|
+    Minitar.unpack(reader, destination)
   end
+  filebeat_full_name = Dir.glob(destination + "/filebeat-*").first
+  File.rename(filebeat_full_name, destination + "/filebeat")
 end

--- a/logstash-input-beats.gemspec
+++ b/logstash-input-beats.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "concurrent-ruby", "~> 1.0"
   s.add_runtime_dependency "thread_safe", "~> 0.3.5"
   s.add_runtime_dependency "logstash-codec-multiline", ">= 2.0.5"
-  s.add_runtime_dependency 'jar-dependencies', '~> 0.3', '>= 0.3.4'
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.3'
   s.add_runtime_dependency 'logstash-mixin-event_support', '~>1.0'
   s.add_runtime_dependency 'logstash-mixin-plugin_factory_support', '~>1.0'


### PR DESCRIPTION
Backport of #509 for 6.x branch
* Remove jar-dependencies dependency
* Fix package installer for ubi8-based testing