### PR TITLE
[logstash-input] Handle connection errors correctly

### DIFF
--- a/src/main/java/org/logstash/beats/BeatsHandler.java
+++ b/src/main/java/org/logstash/beats/BeatsHandler.java
@@ -140,14 +140,14 @@ public class BeatsHandler extends SimpleChannelInboundHandler<Batch> {
     }
 
     private boolean isNoisyException(final Throwable ex) {
-        if (ex instanceof IOException) {
-            final String message = ex.getMessage();
-            if ("Connection reset by peer".equals(message)) {
-                return true;
-            }
-        } else if (ex instanceof SocketException) {
+        if (ex instanceof SocketException) {
             final String message = ex.getMessage();
             if ("Connection reset".equals(message)) {
+                return true;
+            }
+        } else if (ex instanceof IOException) {
+            final String message = ex.getMessage();
+            if ("Connection reset by peer".equals(message)) {
                 return true;
             }
         }

--- a/src/main/java/org/logstash/beats/BeatsHandler.java
+++ b/src/main/java/org/logstash/beats/BeatsHandler.java
@@ -93,11 +93,6 @@ public class BeatsHandler extends SimpleChannelInboundHandler<Batch> {
                 }
             } else {
                 final Throwable realCause = extractCause(cause, 0);
-                if (logger.isDebugEnabled()) {
-                    logger.info(format("Handling exception: " + cause + " (caused by: " + realCause + ")"), cause);
-                } else {
-                    logger.info(format("Handling exception: " + cause + " (caused by: " + realCause + ")"));
-                }
                 // when execution tasks rejected, no need to forward the exception to netty channel handlers
                 if (cause instanceof RejectedExecutionException) {
                     if (logger.isDebugEnabled()) {

--- a/src/main/java/org/logstash/beats/BeatsHandler.java
+++ b/src/main/java/org/logstash/beats/BeatsHandler.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.net.SocketException;
 import java.net.InetSocketAddress;
 import java.util.Objects;
 import java.util.concurrent.RejectedExecutionException;
@@ -99,11 +100,21 @@ public class BeatsHandler extends SimpleChannelInboundHandler<Batch> {
                 }
                 // when execution tasks rejected, no need to forward the exception to netty channel handlers
                 if (cause instanceof RejectedExecutionException) {
+                    if (logger.isDebugEnabled()) {
+                        logger.info(format("Handling exception: " + cause + " (caused by: " + realCause + ")"), cause);
+                    } else {
+                        logger.info(format("Handling exception: " + cause + " (caused by: " + realCause + ")"));
+                    }
                     // we no longer have event executors available since they are terminated, mostly by shutdown process
                     if (Objects.nonNull(cause.getMessage()) && cause.getMessage().contains(executorTerminatedMessage)) {
                         this.isQuietPeriod.compareAndSet(false, true);
                     }
                 } else {
+                    if (logger.isDebugEnabled()) {
+                        logger.info(format("Deteted exception: " + cause + " (caused by: " + realCause + ")"), cause);
+                    } else {
+                        logger.info(format("Detected exception: " + cause + " (caused by: " + realCause + ")"));
+                    }
                     super.exceptionCaught(ctx, cause);
                 }
             }
@@ -137,6 +148,11 @@ public class BeatsHandler extends SimpleChannelInboundHandler<Batch> {
         if (ex instanceof IOException) {
             final String message = ex.getMessage();
             if ("Connection reset by peer".equals(message)) {
+                return true;
+            }
+        } else if (ex instanceof SocketException) {
+            final String message = ex.getMessage();
+            if ("Connection reset".equals(message)) {
                 return true;
             }
         }

--- a/src/main/java/org/logstash/beats/BeatsHandler.java
+++ b/src/main/java/org/logstash/beats/BeatsHandler.java
@@ -106,9 +106,9 @@ public class BeatsHandler extends SimpleChannelInboundHandler<Batch> {
                     }
                 } else {
                     if (logger.isDebugEnabled()) {
-                        logger.info(format("Deteted exception: " + cause + " (caused by: " + realCause + ")"), cause);
+                        logger.warn(format("Unhandled exception: " + cause + " (caused by: " + realCause + ")"), cause);
                     } else {
-                        logger.info(format("Detected exception: " + cause + " (caused by: " + realCause + ")"));
+                        logger.warn(format("Unhandled exception: " + cause + " (caused by: " + realCause + ")"));
                     }
                     super.exceptionCaught(ctx, cause);
                 }

--- a/src/main/java/org/logstash/beats/BeatsHandler.java
+++ b/src/main/java/org/logstash/beats/BeatsHandler.java
@@ -6,7 +6,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
-import java.net.SocketException;
 import java.net.InetSocketAddress;
 import java.util.Objects;
 import java.util.concurrent.RejectedExecutionException;
@@ -140,12 +139,7 @@ public class BeatsHandler extends SimpleChannelInboundHandler<Batch> {
     }
 
     private boolean isNoisyException(final Throwable ex) {
-        if (ex instanceof SocketException) {
-            final String message = ex.getMessage();
-            if ("Connection reset".equals(message)) {
-                return true;
-            }
-        } else if (ex instanceof IOException) {
+        if (ex instanceof IOException) {
             final String message = ex.getMessage();
             if ("Connection reset by peer".equals(message)) {
                 return true;


### PR DESCRIPTION
Current handling of connection errors results in a log message that the case is handled, followed by an error and stack trace because it is not handled.

This change handles this by correcting the logging to indicate when an Error is handled and when it isn't.


Here is an example of connection resets that are not handled because the are not as the expected ones, observed in the wild:
```
[2026-04-14T10:01:18,143][INFO ][org.logstash.beats.BeatsHandler][pipeline-name][0091cc855ef1087f43a697aa15a65059dde76fb10db72eac9d82c3a650a9376e] [local: 192.168.0.2:5001, remote: 192.168.0.11:36316] Handling exception: java.net.SocketException: Connection reset (caused by: java.net.SocketException: Connection reset)
[2026-04-14T10:01:18,143][WARN ][io.netty.channel.DefaultChannelPipeline][pipeline-name][0091cc855ef1087f43a697aa15a65059dde76fb10db72eac9d82c3a650a9376e] An exceptionCaught() event was fired, and it reached at the tail of the pipeline. It usually means the last handler in the pipeline did not handle the exception.
java.net.SocketException: Connection reset
[..]
```

Added 07.2026: The above error is caused by winlogbeat 8.17.10. It is unclear why as I have found no reference to it anywhere and goes away with an update to > 8.18.0 Might be an artifact of virtualized machines. Removed original handling of this error from PR as it's fixed by a client upgrade.

P.S. Please backport to 8.x